### PR TITLE
All changes for now:

### DIFF
--- a/CnCTDRAMapEditor/App.config
+++ b/CnCTDRAMapEditor/App.config
@@ -21,10 +21,10 @@
     <userSettings>
         <MobiusEditor.Properties.Settings>
             <setting name="ShowInviteWarning" serializeAs="String">
-                <value>True</value>
+                <value>False</value>
             </setting>
             <setting name="GameDirectoryPath" serializeAs="String">
-                <value />
+				<value>E:\Games\Steam\steamapps\common\Telstar - CCR</value>
             </setting>
             <setting name="MaxMapTileTextureSize" serializeAs="String">
                 <value>0</value>

--- a/CnCTDRAMapEditor/CnCTDRAMapEditor.csproj
+++ b/CnCTDRAMapEditor/CnCTDRAMapEditor.csproj
@@ -85,6 +85,9 @@
     <Compile Include="Controls\BriefingSettings.Designer.cs">
       <DependentUpon>BriefingSettings.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\EnhNumericUpDown.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Controls\ImageTooltip.cs">
       <SubType>Component</SubType>
     </Compile>
@@ -108,6 +111,12 @@
     </Compile>
     <Compile Include="Controls\PropertiesComboBox.Designer.cs">
       <DependentUpon>PropertiesComboBox.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Controls\SmudgeProperties.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Controls\SmudgeProperties.Designer.cs">
+      <DependentUpon>SmudgeProperties.cs</DependentUpon>
     </Compile>
     <Compile Include="Controls\TerrainProperties.cs">
       <SubType>UserControl</SubType>
@@ -479,6 +488,10 @@
     <EmbeddedResource Include="Controls\MapPanel.resx">
       <DependentUpon>MapPanel.cs</DependentUpon>
     </EmbeddedResource>
+    <EmbeddedResource Include="Controls\SmudgeProperties.resx">
+      <DependentUpon>SmudgeProperties.cs</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Controls\TerrainProperties.resx">
       <DependentUpon>TerrainProperties.cs</DependentUpon>
     </EmbeddedResource>
@@ -563,10 +576,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json">
-      <Version>12.0.3</Version>
+      <Version>13.0.1</Version>
     </PackageReference>
     <PackageReference Include="Pfim">
-      <Version>0.9.1</Version>
+      <Version>0.10.1</Version>
     </PackageReference>
     <PackageReference Include="System.ValueTuple">
       <Version>4.5.0</Version>

--- a/CnCTDRAMapEditor/Controls/EnhNumericUpDown.cs
+++ b/CnCTDRAMapEditor/Controls/EnhNumericUpDown.cs
@@ -1,0 +1,291 @@
+﻿// The Enhanced NumericUpDown is created by Nyerguds, and released under the WTFPL.
+// So go nuts. Use it, steal it, sell it, print it out and burn it in bizarre rituals while dancing naked under the moonlight.
+// I don't judge.
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
+
+namespace MobiusEditor.Controls
+{
+    /// <summary>
+    /// Enhanced NumericUpDown that allows catching the specific "value up/down" and "value entered" events
+    /// instead of "value changed", to avoid unnecessary calls on boxes where values are often typed in.
+    /// Also offers a property to change the amount of items scrolled by the mouse scroll wheel.
+    /// </summary>
+    public class EnhNumericUpDown : NumericUpDown
+    {
+        [DefaultValue(1)]
+        [Category("Data")]
+        [Description("Indicates the amount to increment or decrement on mouse wheel scroll.")]
+        public Int32 MouseWheelIncrement { get; set; }
+        [Category("Action")]
+        [Description("Occurs when the value is changed a single tick through either the up-down arrow keys, the up-down buttons or the scrollwheel.")]
+        public event EventHandler<UpDownEventArgs> ValueUpDown;
+        [Category("Action")]
+        [Description("Occurs when the user presses the Enter key after changing the value.")]
+        public event EventHandler<ValueEnteredEventArgs> ValueEntered;
+        [Category("Data")]
+        [Description("True to make the scrollwheel action cause validation on EnteredValue.")]
+        [DefaultValue(true)]
+        public Boolean ScrollValidatesEnter { get { return this._ScrollValidatesEnter; } set { this._ScrollValidatesEnter = value; } }
+        [Category("Data")]
+        [DefaultValue(true)]
+        [Description("True to make the up-down arrow keys or controls cause validation on EnteredValue.")]
+        public Boolean UpDownValidatesEnter { get { return this._UpDownValidatesEnter; } set { this._UpDownValidatesEnter = value; } }
+
+        /// <summary>
+        /// Last validated entered value.
+        /// </summary>
+        [Category("Data")]
+        [DefaultValue(0)]
+        [Description("The last validated value of the EnhNumericUpDownControl.")]
+        public Decimal EnteredValue
+        {
+            get { return this.Constrain(this._EnteredValue);  }
+            set
+            {
+                this.Value = this.Constrain(value);
+                this.ValidateValue();
+            }
+        }
+
+        private Decimal _EnteredValue;
+        private Boolean _ScrollValidatesEnter = true;
+        private Boolean _UpDownValidatesEnter = true;
+        private TextBox _TextBox;
+
+        public EnhNumericUpDown()
+        {
+            this.MouseWheelIncrement = 1;
+            this.KeyDown += this.CheckKeyPress;
+            foreach (Control control in this.Controls)
+            {
+                if (control is TextBox)
+                {
+                    this._TextBox = control as TextBox;
+                    break;
+                }
+            }
+        }
+
+        public TextBox TextBox { get { return this._TextBox; } }
+
+        protected override void OnTextChanged(EventArgs e)
+        {
+            Boolean allowminus = this.Minimum < 0;
+            Boolean allowHex = this.Hexadecimal;
+            String pattern = allowHex ? "(\\d|[A-F])*" : (allowminus ? "-?\\d*" : "\\d*");
+            if (Regex.IsMatch(this.Text, "^" + pattern + "$", RegexOptions.IgnoreCase))
+                return;
+            // something snuck in, probably with ctrl+v. Remove it.
+            System.Media.SystemSounds.Beep.Play();
+            StringBuilder text = new StringBuilder();
+            String txt = this.Text.ToUpperInvariant();
+            Int32 txtLen = txt.Length;
+            Int32 firstIllegalChar = -1;
+            for (Int32 i = 0; i < txtLen; ++i)
+            {
+                Char c = txt[i];
+                Boolean isNumRange = (c >= '0' && c <= '9');
+                Boolean isAllowedHexRange = allowHex && (c >= 'A' && c <= 'F');
+                Boolean isAllowedMinus = (i == 0 && c == '-' && !allowHex);
+                if (!isNumRange && !isAllowedHexRange && !isAllowedMinus)
+                {
+                    if (firstIllegalChar == -1)
+                        firstIllegalChar = i;
+                    continue;
+                }
+                text.Append(c);
+            }
+            String filteredText = text.ToString();
+            Decimal value;
+            NumberStyles ns = allowHex ? NumberStyles.HexNumber : NumberStyles.Number;
+            if (Decimal.TryParse(filteredText, ns, NumberFormatInfo.CurrentInfo, out value))
+            {
+                value = Math.Max((Int32)this.Minimum, Math.Min(this.Maximum, value));
+                // will trigger this function again, but that's okay, it'll immediately fail the regex and abort.
+                this.Text = value.ToString(CultureInfo.InvariantCulture);
+            }
+            else
+                this.Text = filteredText;
+            if (firstIllegalChar == -1)
+                firstIllegalChar = 0;
+            this.Select(firstIllegalChar, 0);
+        }
+
+        /// <summary>Gets or sets the starting point of text selected in the text box.</summary>
+        public Int32 SelectionStart
+        {
+            get { return this._TextBox.SelectionStart; }
+            set { this._TextBox.SelectionStart = value; }
+        }
+
+        /// <summary>Gets or sets the number of characters selected in the text box.</summary>
+        public Int32 SelectionLength
+        {
+            get { return this._TextBox.SelectionLength; }
+            set { this._TextBox.SelectionLength = value; }
+        }
+
+        /// <summary>Gets or sets a value indicating the currently selected text in the control.</summary>
+        public String SelectedText
+        {
+            get { return this._TextBox.SelectedText; }
+            set { this._TextBox.SelectedText = value; }
+        }
+
+        public void SelectAll()
+        {
+            this._TextBox.SelectionStart = 0;
+            this._TextBox.SelectionLength = this.TextBox.TextLength;
+        }
+
+        protected override void OnMouseWheel(MouseEventArgs e)
+        {
+            HandledMouseEventArgs hme = e as HandledMouseEventArgs;
+            if (hme != null)
+                hme.Handled = true;
+            Int32 delta = e.Delta;
+            Int32 scroll = this.MouseWheelIncrement;
+            // Negative increment is perfectly allowed, but will simply be handled as opposite direction scrolling.
+            if (scroll < 0)
+            {
+                delta = -delta;
+                scroll = -scroll;
+            }
+            UpDownAction action;
+            if (delta > 0)
+            {
+                Decimal value = this.Value + scroll;
+                this.Value = Math.Min(this.Maximum, value);
+                action = UpDownAction.Up;
+            }
+            else if (delta < 0)
+            {
+                Decimal value = this.Value - scroll;
+                this.Value = Math.Max(this.Minimum, value);
+                action = UpDownAction.Down;
+            }
+            else
+                return;
+            if (this.ScrollValidatesEnter)
+                this.ValidateValue();
+            if (this.ValueUpDown != null)
+                this.ValueUpDown(this, new UpDownEventArgs(action, scroll, true));
+        }
+
+        private void CheckKeyPress(Object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                e.SuppressKeyPress = this.ValidateValue();
+            }
+        }
+
+        private Boolean ValidateValue()
+        {
+            Decimal oldval = this._EnteredValue;
+            this._EnteredValue = this.Value;
+            if (this.ValueEntered != null)
+                this.ValueEntered(this, new ValueEnteredEventArgs(oldval));
+            return true;
+        }
+
+        public Decimal Constrain(Decimal value)
+        {
+            if (value < this.Minimum)
+                value = this.Minimum;
+            else if (value > this.Maximum)
+                value = this.Maximum;
+            return value;
+        }
+
+        /// <summary>
+        /// Decrements the value of the spin box (also known as an up-down control).
+        /// </summary>
+        public override void DownButton()
+        {
+            base.DownButton();
+            //Decimal value = this.Value;
+            //this.Value = Math.Max(this.Minimum, value);
+            if (this.UpDownValidatesEnter)
+                this.ValidateValue();
+            if (this.ValueUpDown != null)
+                this.ValueUpDown(this, new UpDownEventArgs(UpDownAction.Down));
+        }
+
+        /// <summary>
+        /// Increments the value of the spin box (also known as an up-down control).
+        /// </summary>
+        public override void UpButton()
+        {
+            base.UpButton();
+            //Decimal value = this.Value;
+            //this.Value = Math.Min(this.Maximum, value);
+            if (this.UpDownValidatesEnter)
+                this.ValidateValue();
+            if (this.ValueUpDown != null)
+                this.ValueUpDown(this, new UpDownEventArgs(UpDownAction.Up));
+        }
+
+        // Sets the value without triggering the "OnValueChanged" event.
+        protected void SetInternalValue(Int32 value)
+        {
+            Type numUpDownType = this.GetType();
+            FieldInfo init = numUpDownType.GetField("initializing");
+            Boolean initializing = (Boolean)init.GetValue(this);
+
+            if (!initializing && ((value < Minimum) || (value > Maximum)))
+            {
+                // Let the system take care of the 'out of range' exception.
+                this.Value = value;
+            }
+            else
+            {
+                FieldInfo val = numUpDownType.GetField("currentValue");
+                val.SetValue(this, value);
+                FieldInfo valChanged = numUpDownType.GetField("currentValueChanged");
+                valChanged.SetValue(this, true);
+                UpdateEditText();
+            }
+        }
+    }
+
+    public class ValueEnteredEventArgs : EventArgs
+    {
+        public Decimal Oldvalue;
+
+        public ValueEnteredEventArgs(Decimal oldvalue)
+        {
+            this.Oldvalue = oldvalue;
+        }
+    }
+
+    public class UpDownEventArgs : EventArgs
+    {
+        public UpDownAction Direction;
+        public Int32 Increment;
+        public Boolean FromMouseWheel;
+
+        public UpDownEventArgs(UpDownAction direction)
+            : this(direction, 1, false)
+        { }
+
+        public UpDownEventArgs(UpDownAction direction, Int32 increment, Boolean fromMouseWheel)
+        {
+            this.Direction = direction;
+            this.Increment = increment;
+            this.FromMouseWheel = fromMouseWheel;
+        }
+    }
+
+    public enum UpDownAction
+    {
+        Up,
+        Down
+    }
+}

--- a/CnCTDRAMapEditor/Controls/SmudgeProperties.Designer.cs
+++ b/CnCTDRAMapEditor/Controls/SmudgeProperties.Designer.cs
@@ -1,0 +1,112 @@
+﻿//
+// Copyright 2020 Electronic Arts Inc.
+//
+// The Command & Conquer Map Editor and corresponding source code is free 
+// software: you can redistribute it and/or modify it under the terms of 
+// the GNU General Public License as published by the Free Software Foundation, 
+// either version 3 of the License, or (at your option) any later version.
+
+// The Command & Conquer Map Editor and corresponding source code is distributed 
+// in the hope that it will be useful, but with permitted additional restrictions 
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT 
+// distributed with this program. You should have received a copy of the 
+// GNU General Public License along with permitted additional restrictions 
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+namespace MobiusEditor.Controls
+{
+    partial class SmudgeProperties
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.label5 = new System.Windows.Forms.Label();
+            this.stateComboBox = new MobiusEditor.Controls.PropertiesComboBox();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 31.25F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 68.75F));
+            this.tableLayoutPanel1.Controls.Add(this.label5, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.stateComboBox, 1, 0);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 1;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(336, 38);
+            this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label5.Location = new System.Drawing.Point(4, 0);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(97, 38);
+            this.label5.TabIndex = 4;
+            this.label5.Text = "Size";
+            this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // triggerComboBox
+            // 
+            this.stateComboBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.stateComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.stateComboBox.FormattingEnabled = true;
+            this.stateComboBox.Location = new System.Drawing.Point(109, 5);
+            this.stateComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.stateComboBox.Name = "triggerComboBox";
+            this.stateComboBox.Size = new System.Drawing.Size(223, 28);
+            this.stateComboBox.TabIndex = 9;
+            this.stateComboBox.SelectedIndexChanged += new System.EventHandler(this.comboBox_SelectedValueChanged);
+            // 
+            // TriggerProperties
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.Name = "TriggerProperties";
+            this.Size = new System.Drawing.Size(336, 38);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.Label label5;
+        private MobiusEditor.Controls.PropertiesComboBox stateComboBox;
+    }
+}

--- a/CnCTDRAMapEditor/Controls/SmudgeProperties.cs
+++ b/CnCTDRAMapEditor/Controls/SmudgeProperties.cs
@@ -16,6 +16,7 @@ using MobiusEditor.Interface;
 using MobiusEditor.Model;
 using MobiusEditor.Utility;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Linq;
@@ -23,30 +24,30 @@ using System.Windows.Forms;
 
 namespace MobiusEditor.Controls
 {
-    public partial class TerrainProperties : UserControl
+    public partial class SmudgeProperties : UserControl
     {
         private bool isMockObject;
 
         public IGamePlugin Plugin { get; private set; }
 
-        private Terrain terrain;
-        public Terrain Terrain
+        private Smudge smudge;
+        public Smudge Smudge
         {
-            get => terrain;
+            get => smudge;
             set
             {
-                if (terrain == value)
-                    return;
-                if (terrain != null)
-                    terrain.PropertyChanged -= Obj_PropertyChanged;
-                terrain = value;
-                if (terrain != null)
-                    terrain.PropertyChanged += Obj_PropertyChanged;
+                if (smudge == value)
+                    return;                
+                if (smudge != null)
+                    smudge.PropertyChanged -= Obj_PropertyChanged;
+                smudge = value;
+                if (smudge != null)
+                    smudge.PropertyChanged += Obj_PropertyChanged;
                 Rebind();
             }
         }
 
-        public TerrainProperties()
+        public SmudgeProperties()
         {
             InitializeComponent();
         }
@@ -56,37 +57,37 @@ namespace MobiusEditor.Controls
             this.isMockObject = isMockObject;
 
             Plugin = plugin;
-            plugin.Map.Triggers.CollectionChanged += Triggers_CollectionChanged;
 
             UpdateDataSource();
 
             Disposed += (sender, e) =>
             {
-                Terrain = null;
-                plugin.Map.Triggers.CollectionChanged -= Triggers_CollectionChanged;
+                Smudge = null;
             };
-        }
-
-        private void Triggers_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            UpdateDataSource();
         }
 
         private void UpdateDataSource()
         {
-            triggerComboBox.DataSource = Trigger.None.Yield().Concat(Plugin.Map.Triggers.Select(t => t.Name).Distinct()).ToArray();
+            int[] data;
+
+            if (smudge != null && smudge.Type.Icons > 1)
+                data = Enumerable.Range(0, smudge.Type.Icons).ToArray();
+            else
+                data = new int[] { 0 };
+            stateComboBox.DataSource = data;
         }
 
         private void Rebind()
         {
-            triggerComboBox.DataBindings.Clear();
+            stateComboBox.DataBindings.Clear();
 
-            if (terrain == null)
+            if (smudge == null)
             {
                 return;
             }
-
-            triggerComboBox.DataBindings.Add("SelectedItem", terrain, "Trigger");
+            UpdateDataSource();
+            stateComboBox.DataBindings.Add("SelectedItem", smudge, "Icon");
+            stateComboBox.Enabled = stateComboBox.Items.Count > 1;
         }
 
         private void Obj_PropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -122,29 +123,29 @@ namespace MobiusEditor.Controls
         }
     }
 
-    public class TerrainPropertiesPopup : ToolStripDropDown
+    public class SmudgePropertiesPopup : ToolStripDropDown
     {
         private readonly ToolStripControlHost host;
 
-        public TerrainProperties TerrainProperties { get; private set; }
+        public SmudgeProperties SmudgeProperties { get; private set; }
 
-        public TerrainPropertiesPopup(IGamePlugin plugin, Terrain terrain)
+        public SmudgePropertiesPopup(IGamePlugin plugin, Smudge smudge)
         {
-            TerrainProperties = new TerrainProperties();
-            TerrainProperties.Initialize(plugin, false);
-            TerrainProperties.Terrain = terrain;
+            SmudgeProperties = new SmudgeProperties();
+            SmudgeProperties.Smudge = smudge;
+            SmudgeProperties.Initialize(plugin, false);
 
-            host = new ToolStripControlHost(TerrainProperties);
+            host = new ToolStripControlHost(SmudgeProperties);
             Padding = Margin = host.Padding = host.Margin = Padding.Empty;
-            MinimumSize = TerrainProperties.MinimumSize;
-            TerrainProperties.MinimumSize = TerrainProperties.Size;
-            MaximumSize = TerrainProperties.MaximumSize;
-            TerrainProperties.MaximumSize = TerrainProperties.Size;
-            Size = TerrainProperties.Size;
+            MinimumSize = SmudgeProperties.MinimumSize;
+            SmudgeProperties.MinimumSize = SmudgeProperties.Size;
+            MaximumSize = SmudgeProperties.MaximumSize;
+            SmudgeProperties.MaximumSize = SmudgeProperties.Size;
+            Size = SmudgeProperties.Size;
             Items.Add(host);
-            TerrainProperties.Disposed += (sender, e) =>
+            SmudgeProperties.Disposed += (sender, e) =>
             {
-                TerrainProperties = null;
+                SmudgeProperties = null;
                 Dispose(true);
             };
         }
@@ -153,7 +154,7 @@ namespace MobiusEditor.Controls
         {
             base.OnClosed(e);
 
-            TerrainProperties.Terrain = null;
+            SmudgeProperties.Smudge = null;
         }
     }
 }

--- a/CnCTDRAMapEditor/Controls/SmudgeProperties.resx
+++ b/CnCTDRAMapEditor/Controls/SmudgeProperties.resx
@@ -117,31 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="teamsTypeColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="teamsCountColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="missionsMissionColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="missionsArgumentColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="teamsTypeColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="teamsCountColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="missionsMissionColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="missionsArgumentColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="teamTypesContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/CnCTDRAMapEditor/Controls/TypeComboBox.cs
+++ b/CnCTDRAMapEditor/Controls/TypeComboBox.cs
@@ -54,7 +54,7 @@ namespace MobiusEditor.Controls
         {
             base.OnMeasureItem(e);
 
-            var typeItem = Items[e.Index] as TypeItem<IBrowsableType>;
+            var typeItem = this.Items[e.Index] as TypeItem<IBrowsableType>;
             if (typeItem?.Type != null)
             {
                 e.ItemHeight = (int)((typeItem.Type.Thumbnail?.Height ?? MissingThumbnail.Height) * 
@@ -88,7 +88,7 @@ namespace MobiusEditor.Controls
                         var thumbnail = typeItem.Type.Thumbnail ?? MissingThumbnail;
                         var thumbnailWidth = (int)Math.Min((e.Bounds.Width - textSize.Width),
                             thumbnail.Width);
-                        int thumbnailHeight = (int)Math.Min(e.Bounds.Height, thumbnail.Height);
+                        int thumbnailHeight = (int)Math.Min(e.Bounds.Height, Math.Max(textSize.Height, thumbnail.Height));
 
                         double widthRatio = (e.Bounds.Width - textSize.Width) / (double)thumbnail.Width;
                         double heightRatio = e.Bounds.Height / (double)thumbnail.Height;

--- a/CnCTDRAMapEditor/Controls/TypeListBox.cs
+++ b/CnCTDRAMapEditor/Controls/TypeListBox.cs
@@ -22,7 +22,7 @@ namespace MobiusEditor.Controls
             set
             {
                 DataSource = value.Select(t => new TypeItem<IBrowsableType>(t.DisplayName, t)).ToArray();
-                ItemHeight = Math.Max(ItemHeight, value.Max(t => (t.Thumbnail?.Height ?? MissingThumbnail.Height)));
+                ItemHeight = Math.Min(255,Math.Max(ItemHeight, value.Max(t => (t.Thumbnail?.Height ?? MissingThumbnail.Height))));
                 Invalidate();
             }
         }
@@ -42,8 +42,13 @@ namespace MobiusEditor.Controls
             var typeItem = Items[e.Index] as TypeItem<IBrowsableType>;
             if (typeItem?.Type != null)
             {
-                e.ItemHeight = Math.Min((int)((typeItem.Type.Thumbnail?.Height ?? MissingThumbnail.Height) *
-                    Properties.Settings.Default.ObjectToolItemSizeMultiplier), MaxListBoxItemHeight);
+                StringFormat stringFormat = new StringFormat
+                {
+                    LineAlignment = StringAlignment.Center
+                };
+                var textSize = e.Graphics.MeasureString(typeItem.Name, Font, e.ItemWidth, stringFormat);
+                e.ItemHeight = Math.Max((int)textSize.Height, Math.Min((int)((typeItem.Type.Thumbnail?.Height ?? MissingThumbnail.Height) *
+                    Properties.Settings.Default.ObjectToolItemSizeMultiplier), MaxListBoxItemHeight));
             }
         }
 

--- a/CnCTDRAMapEditor/Controls/ViewToolStripButton.cs
+++ b/CnCTDRAMapEditor/Controls/ViewToolStripButton.cs
@@ -1,10 +1,14 @@
 ﻿using MobiusEditor.Interface;
+using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 
 namespace MobiusEditor.Controls
 {
     public class ViewToolStripButton : ToolStripButton
     {
+        [Category("Behavior")]
         public ToolType ToolType { get; set; }
+
     }
 }

--- a/CnCTDRAMapEditor/Dialogs/InviteMessageBox.Designer.cs
+++ b/CnCTDRAMapEditor/Dialogs/InviteMessageBox.Designer.cs
@@ -21,19 +21,6 @@ namespace MobiusEditor.Dialogs
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary>
-        /// Clean up any resources being used.
-        /// </summary>
-        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing && (components != null))
-            {
-                components.Dispose();
-            }
-            base.Dispose(disposing);
-        }
-
         #region Windows Form Designer generated code
 
         /// <summary>

--- a/CnCTDRAMapEditor/Dialogs/InviteMessageBox.cs
+++ b/CnCTDRAMapEditor/Dialogs/InviteMessageBox.cs
@@ -34,5 +34,22 @@ namespace MobiusEditor.Dialogs
                 pictureBoxIcon.Image = infoIcon.ToBitmap();
             }
         }
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                var img = pictureBoxIcon.Image;
+                pictureBoxIcon.Image = null;
+                try { img.Dispose(); }
+                catch { /* ignore */ }
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
     }
 }

--- a/CnCTDRAMapEditor/Dialogs/MapSettingsDialog.cs
+++ b/CnCTDRAMapEditor/Dialogs/MapSettingsDialog.cs
@@ -121,7 +121,10 @@ namespace MobiusEditor.Dialogs
             }
             else
             {
-                e.Graphics.DrawString(e.Node.Text, e.Node.TreeView.Font, new SolidBrush(settingsTreeView.ForeColor), e.Node.Bounds.X, e.Node.Bounds.Y);
+                using (var brush = new SolidBrush(settingsTreeView.ForeColor))
+                {
+                    e.Graphics.DrawString(e.Node.Text, e.Node.TreeView.Font, brush, e.Node.Bounds.X, e.Node.Bounds.Y);
+                }
             }
         }
 

--- a/CnCTDRAMapEditor/Dialogs/TeamTypesDialog.Designer.cs
+++ b/CnCTDRAMapEditor/Dialogs/TeamTypesDialog.Designer.cs
@@ -12,6 +12,9 @@
 // distributed with this program. You should have received a copy of the 
 // GNU General Public License along with permitted additional restrictions 
 // with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+using System;
+using System.Windows.Forms;
+
 namespace MobiusEditor.Dialogs
 {
     partial class TeamTypesDialog
@@ -85,6 +88,8 @@ namespace MobiusEditor.Dialogs
             this.teamTypesContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.addTeamTypeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.removeTeamTypeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
+            this.btnAdd = new System.Windows.Forms.Button();
             this.tableLayoutPanel1.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.settingsPanel.SuspendLayout();
@@ -98,6 +103,7 @@ namespace MobiusEditor.Dialogs
             ((System.ComponentModel.ISupportInitialize)(this.teamsDataGridView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.missionsDataGridView)).BeginInit();
             this.teamTypesContextMenuStrip.SuspendLayout();
+            this.flowLayoutPanel2.SuspendLayout();
             this.SuspendLayout();
             // 
             // tableLayoutPanel1
@@ -105,42 +111,41 @@ namespace MobiusEditor.Dialogs
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 20F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 80F));
-            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel2, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 1, 1);
             this.tableLayoutPanel1.Controls.Add(this.settingsPanel, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.teamTypesListView, 0, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1313, 640);
-            this.tableLayoutPanel1.TabIndex = 1;
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(875, 416);
+            this.tableLayoutPanel1.TabIndex = 2;
             // 
             // flowLayoutPanel1
             // 
             this.flowLayoutPanel1.AutoSize = true;
             this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 2);
             this.flowLayoutPanel1.Controls.Add(this.btnCancel);
             this.flowLayoutPanel1.Controls.Add(this.btnOK);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(4, 583);
-            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(178, 379);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(1305, 52);
-            this.flowLayoutPanel1.TabIndex = 1;
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(694, 34);
+            this.flowLayoutPanel1.TabIndex = 3;
             // 
             // btnCancel
             // 
             this.btnCancel.AutoSize = true;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(1200, 3);
+            this.btnCancel.Location = new System.Drawing.Point(624, 2);
+            this.btnCancel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(102, 46);
-            this.btnCancel.TabIndex = 2;
+            this.btnCancel.Size = new System.Drawing.Size(68, 30);
+            this.btnCancel.TabIndex = 41;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             // 
@@ -148,10 +153,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.btnOK.AutoSize = true;
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(1119, 3);
+            this.btnOK.Location = new System.Drawing.Point(570, 2);
+            this.btnOK.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.btnOK.Name = "btnOK";
-            this.btnOK.Size = new System.Drawing.Size(75, 46);
-            this.btnOK.TabIndex = 3;
+            this.btnOK.Size = new System.Drawing.Size(50, 30);
+            this.btnOK.TabIndex = 40;
             this.btnOK.Text = "&OK";
             this.btnOK.UseVisualStyleBackColor = true;
             // 
@@ -159,11 +165,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.settingsPanel.Controls.Add(this.teamTypeTableLayoutPanel);
             this.settingsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.settingsPanel.Location = new System.Drawing.Point(277, 15);
-            this.settingsPanel.Margin = new System.Windows.Forms.Padding(15);
+            this.settingsPanel.Location = new System.Drawing.Point(185, 10);
+            this.settingsPanel.Margin = new System.Windows.Forms.Padding(10, 10, 10, 10);
             this.settingsPanel.Name = "settingsPanel";
-            this.settingsPanel.Size = new System.Drawing.Size(1021, 548);
-            this.settingsPanel.TabIndex = 3;
+            this.settingsPanel.Size = new System.Drawing.Size(680, 356);
+            this.settingsPanel.TabIndex = 2;
             // 
             // teamTypeTableLayoutPanel
             // 
@@ -175,11 +181,12 @@ namespace MobiusEditor.Dialogs
             this.teamTypeTableLayoutPanel.Controls.Add(this.tableLayoutPanel3, 2, 0);
             this.teamTypeTableLayoutPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.teamTypeTableLayoutPanel.Location = new System.Drawing.Point(0, 0);
+            this.teamTypeTableLayoutPanel.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.teamTypeTableLayoutPanel.Name = "teamTypeTableLayoutPanel";
             this.teamTypeTableLayoutPanel.RowCount = 1;
             this.teamTypeTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.teamTypeTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 548F));
-            this.teamTypeTableLayoutPanel.Size = new System.Drawing.Size(1021, 548);
+            this.teamTypeTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 356F));
+            this.teamTypeTableLayoutPanel.Size = new System.Drawing.Size(680, 356);
             this.teamTypeTableLayoutPanel.TabIndex = 0;
             // 
             // tableLayoutPanel2
@@ -210,7 +217,8 @@ namespace MobiusEditor.Dialogs
             this.tableLayoutPanel2.Controls.Add(this.label9, 0, 8);
             this.tableLayoutPanel2.Controls.Add(this.recruitPriorityNud, 1, 8);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(3, 3);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(2, 2);
+            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 15;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -228,16 +236,17 @@ namespace MobiusEditor.Dialogs
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(307, 542);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(206, 352);
             this.tableLayoutPanel2.TabIndex = 0;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
             this.label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label1.Location = new System.Drawing.Point(3, 0);
+            this.label1.Location = new System.Drawing.Point(2, 0);
+            this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(100, 34);
+            this.label1.Size = new System.Drawing.Size(67, 25);
             this.label1.TabIndex = 0;
             this.label1.Text = "House";
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -248,20 +257,22 @@ namespace MobiusEditor.Dialogs
             this.houseComboBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.houseComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.houseComboBox.FormattingEnabled = true;
-            this.houseComboBox.Location = new System.Drawing.Point(109, 3);
+            this.houseComboBox.Location = new System.Drawing.Point(73, 2);
+            this.houseComboBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.houseComboBox.Name = "houseComboBox";
-            this.houseComboBox.Size = new System.Drawing.Size(195, 28);
-            this.houseComboBox.TabIndex = 1;
+            this.houseComboBox.Size = new System.Drawing.Size(131, 21);
+            this.houseComboBox.TabIndex = 10;
             this.houseComboBox.ValueMember = "Type";
             // 
             // roundaboutCheckBox
             // 
             this.roundaboutCheckBox.AutoSize = true;
             this.roundaboutCheckBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.roundaboutCheckBox.Location = new System.Drawing.Point(109, 37);
+            this.roundaboutCheckBox.Location = new System.Drawing.Point(73, 27);
+            this.roundaboutCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.roundaboutCheckBox.Name = "roundaboutCheckBox";
-            this.roundaboutCheckBox.Size = new System.Drawing.Size(195, 24);
-            this.roundaboutCheckBox.TabIndex = 2;
+            this.roundaboutCheckBox.Size = new System.Drawing.Size(131, 17);
+            this.roundaboutCheckBox.TabIndex = 11;
             this.roundaboutCheckBox.Text = "Roundabout";
             this.roundaboutCheckBox.UseVisualStyleBackColor = true;
             // 
@@ -269,10 +280,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.learningCheckBox.AutoSize = true;
             this.learningCheckBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.learningCheckBox.Location = new System.Drawing.Point(109, 67);
+            this.learningCheckBox.Location = new System.Drawing.Point(73, 48);
+            this.learningCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.learningCheckBox.Name = "learningCheckBox";
-            this.learningCheckBox.Size = new System.Drawing.Size(195, 24);
-            this.learningCheckBox.TabIndex = 3;
+            this.learningCheckBox.Size = new System.Drawing.Size(131, 17);
+            this.learningCheckBox.TabIndex = 12;
             this.learningCheckBox.Text = "Learning";
             this.learningCheckBox.UseVisualStyleBackColor = true;
             // 
@@ -280,10 +292,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.suicideCheckBox.AutoSize = true;
             this.suicideCheckBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.suicideCheckBox.Location = new System.Drawing.Point(109, 97);
+            this.suicideCheckBox.Location = new System.Drawing.Point(73, 69);
+            this.suicideCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.suicideCheckBox.Name = "suicideCheckBox";
-            this.suicideCheckBox.Size = new System.Drawing.Size(195, 24);
-            this.suicideCheckBox.TabIndex = 4;
+            this.suicideCheckBox.Size = new System.Drawing.Size(131, 17);
+            this.suicideCheckBox.TabIndex = 13;
             this.suicideCheckBox.Text = "Suicide";
             this.suicideCheckBox.UseVisualStyleBackColor = true;
             // 
@@ -291,10 +304,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.autocreateCheckBox.AutoSize = true;
             this.autocreateCheckBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.autocreateCheckBox.Location = new System.Drawing.Point(109, 127);
+            this.autocreateCheckBox.Location = new System.Drawing.Point(73, 90);
+            this.autocreateCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.autocreateCheckBox.Name = "autocreateCheckBox";
-            this.autocreateCheckBox.Size = new System.Drawing.Size(195, 24);
-            this.autocreateCheckBox.TabIndex = 5;
+            this.autocreateCheckBox.Size = new System.Drawing.Size(131, 17);
+            this.autocreateCheckBox.TabIndex = 14;
             this.autocreateCheckBox.Text = "Auto-create";
             this.autocreateCheckBox.UseVisualStyleBackColor = true;
             // 
@@ -302,10 +316,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.mercernaryCheckBox.AutoSize = true;
             this.mercernaryCheckBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.mercernaryCheckBox.Location = new System.Drawing.Point(109, 157);
+            this.mercernaryCheckBox.Location = new System.Drawing.Point(73, 111);
+            this.mercernaryCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.mercernaryCheckBox.Name = "mercernaryCheckBox";
-            this.mercernaryCheckBox.Size = new System.Drawing.Size(195, 24);
-            this.mercernaryCheckBox.TabIndex = 6;
+            this.mercernaryCheckBox.Size = new System.Drawing.Size(131, 17);
+            this.mercernaryCheckBox.TabIndex = 15;
             this.mercernaryCheckBox.Text = "Mercernary";
             this.mercernaryCheckBox.UseVisualStyleBackColor = true;
             // 
@@ -313,10 +328,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.reinforcableCheckBox.AutoSize = true;
             this.reinforcableCheckBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.reinforcableCheckBox.Location = new System.Drawing.Point(109, 187);
+            this.reinforcableCheckBox.Location = new System.Drawing.Point(73, 132);
+            this.reinforcableCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.reinforcableCheckBox.Name = "reinforcableCheckBox";
-            this.reinforcableCheckBox.Size = new System.Drawing.Size(195, 24);
-            this.reinforcableCheckBox.TabIndex = 7;
+            this.reinforcableCheckBox.Size = new System.Drawing.Size(131, 17);
+            this.reinforcableCheckBox.TabIndex = 16;
             this.reinforcableCheckBox.Text = "Reinforcable";
             this.reinforcableCheckBox.UseVisualStyleBackColor = true;
             // 
@@ -324,10 +340,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.prebuiltCheckBox.AutoSize = true;
             this.prebuiltCheckBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.prebuiltCheckBox.Location = new System.Drawing.Point(109, 217);
+            this.prebuiltCheckBox.Location = new System.Drawing.Point(73, 153);
+            this.prebuiltCheckBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.prebuiltCheckBox.Name = "prebuiltCheckBox";
-            this.prebuiltCheckBox.Size = new System.Drawing.Size(195, 24);
-            this.prebuiltCheckBox.TabIndex = 8;
+            this.prebuiltCheckBox.Size = new System.Drawing.Size(131, 17);
+            this.prebuiltCheckBox.TabIndex = 17;
             this.prebuiltCheckBox.Text = "Prebuilt";
             this.prebuiltCheckBox.UseVisualStyleBackColor = true;
             // 
@@ -335,9 +352,10 @@ namespace MobiusEditor.Dialogs
             // 
             this.label2.AutoSize = true;
             this.label2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label2.Location = new System.Drawing.Point(3, 276);
+            this.label2.Location = new System.Drawing.Point(2, 196);
+            this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(100, 32);
+            this.label2.Size = new System.Drawing.Size(67, 24);
             this.label2.TabIndex = 9;
             this.label2.Text = "Init Num";
             this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -346,9 +364,10 @@ namespace MobiusEditor.Dialogs
             // 
             this.label3.AutoSize = true;
             this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label3.Location = new System.Drawing.Point(3, 308);
+            this.label3.Location = new System.Drawing.Point(2, 220);
+            this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(100, 32);
+            this.label3.Size = new System.Drawing.Size(67, 24);
             this.label3.TabIndex = 10;
             this.label3.Text = "Max Allowed";
             this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -357,9 +376,10 @@ namespace MobiusEditor.Dialogs
             // 
             this.label4.AutoSize = true;
             this.label4.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label4.Location = new System.Drawing.Point(3, 340);
+            this.label4.Location = new System.Drawing.Point(2, 244);
+            this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(100, 32);
+            this.label4.Size = new System.Drawing.Size(67, 24);
             this.label4.TabIndex = 11;
             this.label4.Text = "Fear";
             this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -367,49 +387,53 @@ namespace MobiusEditor.Dialogs
             // initNumNud
             // 
             this.initNumNud.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.initNumNud.Location = new System.Drawing.Point(109, 279);
+            this.initNumNud.Location = new System.Drawing.Point(73, 198);
+            this.initNumNud.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.initNumNud.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.initNumNud.Name = "initNumNud";
-            this.initNumNud.Size = new System.Drawing.Size(195, 26);
-            this.initNumNud.TabIndex = 12;
+            this.initNumNud.Size = new System.Drawing.Size(131, 20);
+            this.initNumNud.TabIndex = 19;
             // 
             // maxAllowedNud
             // 
             this.maxAllowedNud.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.maxAllowedNud.Location = new System.Drawing.Point(109, 311);
+            this.maxAllowedNud.Location = new System.Drawing.Point(73, 222);
+            this.maxAllowedNud.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.maxAllowedNud.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.maxAllowedNud.Name = "maxAllowedNud";
-            this.maxAllowedNud.Size = new System.Drawing.Size(195, 26);
-            this.maxAllowedNud.TabIndex = 13;
+            this.maxAllowedNud.Size = new System.Drawing.Size(131, 20);
+            this.maxAllowedNud.TabIndex = 20;
             // 
             // fearNud
             // 
             this.fearNud.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.fearNud.Location = new System.Drawing.Point(109, 343);
+            this.fearNud.Location = new System.Drawing.Point(73, 246);
+            this.fearNud.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.fearNud.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.fearNud.Name = "fearNud";
-            this.fearNud.Size = new System.Drawing.Size(195, 26);
-            this.fearNud.TabIndex = 14;
+            this.fearNud.Size = new System.Drawing.Size(131, 20);
+            this.fearNud.TabIndex = 21;
             // 
             // waypointLabel
             // 
             this.waypointLabel.AutoSize = true;
             this.waypointLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.waypointLabel.Location = new System.Drawing.Point(3, 372);
+            this.waypointLabel.Location = new System.Drawing.Point(2, 268);
+            this.waypointLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.waypointLabel.Name = "waypointLabel";
-            this.waypointLabel.Size = new System.Drawing.Size(100, 34);
+            this.waypointLabel.Size = new System.Drawing.Size(67, 25);
             this.waypointLabel.TabIndex = 15;
             this.waypointLabel.Text = "Waypoint";
             this.waypointLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -418,9 +442,10 @@ namespace MobiusEditor.Dialogs
             // 
             this.triggerLabel.AutoSize = true;
             this.triggerLabel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.triggerLabel.Location = new System.Drawing.Point(3, 406);
+            this.triggerLabel.Location = new System.Drawing.Point(2, 293);
+            this.triggerLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.triggerLabel.Name = "triggerLabel";
-            this.triggerLabel.Size = new System.Drawing.Size(100, 34);
+            this.triggerLabel.Size = new System.Drawing.Size(67, 25);
             this.triggerLabel.TabIndex = 16;
             this.triggerLabel.Text = "Trigger";
             this.triggerLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -430,27 +455,30 @@ namespace MobiusEditor.Dialogs
             this.waypointComboBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.waypointComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.waypointComboBox.FormattingEnabled = true;
-            this.waypointComboBox.Location = new System.Drawing.Point(109, 375);
+            this.waypointComboBox.Location = new System.Drawing.Point(73, 270);
+            this.waypointComboBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.waypointComboBox.Name = "waypointComboBox";
-            this.waypointComboBox.Size = new System.Drawing.Size(195, 28);
-            this.waypointComboBox.TabIndex = 17;
+            this.waypointComboBox.Size = new System.Drawing.Size(131, 21);
+            this.waypointComboBox.TabIndex = 22;
             // 
             // triggerComboBox
             // 
             this.triggerComboBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.triggerComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.triggerComboBox.FormattingEnabled = true;
-            this.triggerComboBox.Location = new System.Drawing.Point(109, 409);
+            this.triggerComboBox.Location = new System.Drawing.Point(73, 295);
+            this.triggerComboBox.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.triggerComboBox.Name = "triggerComboBox";
-            this.triggerComboBox.Size = new System.Drawing.Size(195, 28);
-            this.triggerComboBox.TabIndex = 18;
+            this.triggerComboBox.Size = new System.Drawing.Size(131, 21);
+            this.triggerComboBox.TabIndex = 23;
             // 
             // label9
             // 
             this.label9.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label9.Location = new System.Drawing.Point(3, 244);
+            this.label9.Location = new System.Drawing.Point(2, 172);
+            this.label9.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(100, 32);
+            this.label9.Size = new System.Drawing.Size(67, 24);
             this.label9.TabIndex = 19;
             this.label9.Text = "Priority";
             this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -458,7 +486,8 @@ namespace MobiusEditor.Dialogs
             // recruitPriorityNud
             // 
             this.recruitPriorityNud.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.recruitPriorityNud.Location = new System.Drawing.Point(109, 247);
+            this.recruitPriorityNud.Location = new System.Drawing.Point(73, 174);
+            this.recruitPriorityNud.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.recruitPriorityNud.Maximum = new decimal(new int[] {
             2147483647,
             0,
@@ -470,8 +499,8 @@ namespace MobiusEditor.Dialogs
             0,
             -2147483648});
             this.recruitPriorityNud.Name = "recruitPriorityNud";
-            this.recruitPriorityNud.Size = new System.Drawing.Size(195, 26);
-            this.recruitPriorityNud.TabIndex = 20;
+            this.recruitPriorityNud.Size = new System.Drawing.Size(131, 20);
+            this.recruitPriorityNud.TabIndex = 18;
             // 
             // tableLayoutPanel3
             // 
@@ -483,29 +512,32 @@ namespace MobiusEditor.Dialogs
             this.tableLayoutPanel3.Controls.Add(this.teamsDataGridView, 0, 1);
             this.tableLayoutPanel3.Controls.Add(this.missionsDataGridView, 1, 1);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(316, 3);
+            this.tableLayoutPanel3.Location = new System.Drawing.Point(212, 2);
+            this.tableLayoutPanel3.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
             this.tableLayoutPanel3.RowCount = 2;
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(702, 542);
-            this.tableLayoutPanel3.TabIndex = 1;
+            this.tableLayoutPanel3.Size = new System.Drawing.Size(466, 352);
+            this.tableLayoutPanel3.TabIndex = 24;
             // 
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(3, 0);
+            this.label7.Location = new System.Drawing.Point(2, 0);
+            this.label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(57, 20);
+            this.label7.Size = new System.Drawing.Size(39, 13);
             this.label7.TabIndex = 0;
             this.label7.Text = "Teams";
             // 
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(354, 0);
+            this.label8.Location = new System.Drawing.Point(235, 0);
+            this.label8.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(70, 20);
+            this.label8.Size = new System.Drawing.Size(47, 13);
             this.label8.TabIndex = 1;
             this.label8.Text = "Missions";
             // 
@@ -518,15 +550,17 @@ namespace MobiusEditor.Dialogs
             this.teamsTypeColumn,
             this.teamsCountColumn});
             this.teamsDataGridView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.teamsDataGridView.Location = new System.Drawing.Point(3, 23);
+            this.teamsDataGridView.Location = new System.Drawing.Point(2, 15);
+            this.teamsDataGridView.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.teamsDataGridView.Name = "teamsDataGridView";
             this.teamsDataGridView.RowTemplate.Height = 28;
-            this.teamsDataGridView.Size = new System.Drawing.Size(345, 516);
-            this.teamsDataGridView.TabIndex = 2;
+            this.teamsDataGridView.Size = new System.Drawing.Size(229, 335);
+            this.teamsDataGridView.TabIndex = 30;
             this.teamsDataGridView.VirtualMode = true;
             this.teamsDataGridView.CancelRowEdit += new System.Windows.Forms.QuestionEventHandler(this.teamsDataGridView_CancelRowEdit);
             this.teamsDataGridView.CellValueNeeded += new System.Windows.Forms.DataGridViewCellValueEventHandler(this.teamsDataGridView_CellValueNeeded);
             this.teamsDataGridView.CellValuePushed += new System.Windows.Forms.DataGridViewCellValueEventHandler(this.teamsDataGridView_CellValuePushed);
+            this.teamsDataGridView.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.DataGridView_DataError);
             this.teamsDataGridView.NewRowNeeded += new System.Windows.Forms.DataGridViewRowEventHandler(this.teamsDataGridView_NewRowNeeded);
             this.teamsDataGridView.RowDirtyStateNeeded += new System.Windows.Forms.QuestionEventHandler(this.teamsDataGridView_RowDirtyStateNeeded);
             this.teamsDataGridView.RowValidated += new System.Windows.Forms.DataGridViewCellEventHandler(this.teamsDataGridView_RowValidated);
@@ -538,13 +572,13 @@ namespace MobiusEditor.Dialogs
             // 
             this.teamsTypeColumn.HeaderText = "Type";
             this.teamsTypeColumn.Name = "teamsTypeColumn";
-            this.teamsTypeColumn.Width = 54;
+            this.teamsTypeColumn.Width = 39;
             // 
             // teamsCountColumn
             // 
             this.teamsCountColumn.HeaderText = "Count";
             this.teamsCountColumn.Name = "teamsCountColumn";
-            this.teamsCountColumn.Width = 88;
+            this.teamsCountColumn.Width = 60;
             // 
             // missionsDataGridView
             // 
@@ -555,15 +589,17 @@ namespace MobiusEditor.Dialogs
             this.missionsMissionColumn,
             this.missionsArgumentColumn});
             this.missionsDataGridView.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.missionsDataGridView.Location = new System.Drawing.Point(354, 23);
+            this.missionsDataGridView.Location = new System.Drawing.Point(235, 15);
+            this.missionsDataGridView.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.missionsDataGridView.Name = "missionsDataGridView";
             this.missionsDataGridView.RowTemplate.Height = 28;
-            this.missionsDataGridView.Size = new System.Drawing.Size(345, 516);
-            this.missionsDataGridView.TabIndex = 3;
+            this.missionsDataGridView.Size = new System.Drawing.Size(229, 335);
+            this.missionsDataGridView.TabIndex = 31;
             this.missionsDataGridView.VirtualMode = true;
             this.missionsDataGridView.CancelRowEdit += new System.Windows.Forms.QuestionEventHandler(this.missionsDataGridView_CancelRowEdit);
             this.missionsDataGridView.CellValueNeeded += new System.Windows.Forms.DataGridViewCellValueEventHandler(this.missionsDataGridView_CellValueNeeded);
             this.missionsDataGridView.CellValuePushed += new System.Windows.Forms.DataGridViewCellValueEventHandler(this.missionsDataGridView_CellValuePushed);
+            this.missionsDataGridView.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.DataGridView_DataError);
             this.missionsDataGridView.NewRowNeeded += new System.Windows.Forms.DataGridViewRowEventHandler(this.missionsDataGridView_NewRowNeeded);
             this.missionsDataGridView.RowDirtyStateNeeded += new System.Windows.Forms.QuestionEventHandler(this.missionsDataGridView_RowDirtyStateNeeded);
             this.missionsDataGridView.RowValidated += new System.Windows.Forms.DataGridViewCellEventHandler(this.missionsDataGridView_RowValidated);
@@ -575,13 +611,13 @@ namespace MobiusEditor.Dialogs
             // 
             this.missionsMissionColumn.HeaderText = "Mission";
             this.missionsMissionColumn.Name = "missionsMissionColumn";
-            this.missionsMissionColumn.Width = 68;
+            this.missionsMissionColumn.Width = 48;
             // 
             // missionsArgumentColumn
             // 
             this.missionsArgumentColumn.HeaderText = "Argument";
             this.missionsArgumentColumn.Name = "missionsArgumentColumn";
-            this.missionsArgumentColumn.Width = 115;
+            this.missionsArgumentColumn.Width = 77;
             // 
             // teamTypesListView
             // 
@@ -591,12 +627,13 @@ namespace MobiusEditor.Dialogs
             this.teamTypesListView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.None;
             this.teamTypesListView.HideSelection = false;
             this.teamTypesListView.LabelEdit = true;
-            this.teamTypesListView.Location = new System.Drawing.Point(3, 3);
+            this.teamTypesListView.Location = new System.Drawing.Point(2, 2);
+            this.teamTypesListView.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.teamTypesListView.MultiSelect = false;
             this.teamTypesListView.Name = "teamTypesListView";
             this.teamTypesListView.ShowItemToolTips = true;
-            this.teamTypesListView.Size = new System.Drawing.Size(256, 572);
-            this.teamTypesListView.TabIndex = 4;
+            this.teamTypesListView.Size = new System.Drawing.Size(171, 372);
+            this.teamTypesListView.TabIndex = 0;
             this.teamTypesListView.UseCompatibleStateImageBehavior = false;
             this.teamTypesListView.View = System.Windows.Forms.View.Details;
             this.teamTypesListView.AfterLabelEdit += new System.Windows.Forms.LabelEditEventHandler(this.teamTypesListView_AfterLabelEdit);
@@ -611,31 +648,54 @@ namespace MobiusEditor.Dialogs
             this.addTeamTypeToolStripMenuItem,
             this.removeTeamTypeToolStripMenuItem});
             this.teamTypesContextMenuStrip.Name = "teamTypesContextMenuStrip";
-            this.teamTypesContextMenuStrip.Size = new System.Drawing.Size(237, 64);
+            this.teamTypesContextMenuStrip.Size = new System.Drawing.Size(180, 48);
             // 
             // addTeamTypeToolStripMenuItem
             // 
             this.addTeamTypeToolStripMenuItem.Name = "addTeamTypeToolStripMenuItem";
-            this.addTeamTypeToolStripMenuItem.Size = new System.Drawing.Size(236, 30);
+            this.addTeamTypeToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.addTeamTypeToolStripMenuItem.Text = "&Add Team Type";
             this.addTeamTypeToolStripMenuItem.Click += new System.EventHandler(this.addTeamTypeToolStripMenuItem_Click);
             // 
             // removeTeamTypeToolStripMenuItem
             // 
             this.removeTeamTypeToolStripMenuItem.Name = "removeTeamTypeToolStripMenuItem";
-            this.removeTeamTypeToolStripMenuItem.Size = new System.Drawing.Size(236, 30);
+            this.removeTeamTypeToolStripMenuItem.Size = new System.Drawing.Size(179, 22);
             this.removeTeamTypeToolStripMenuItem.Text = "&Remove Team Type";
             this.removeTeamTypeToolStripMenuItem.Click += new System.EventHandler(this.removeTeamTypeToolStripMenuItem_Click);
             // 
+            // flowLayoutPanel2
+            // 
+            this.flowLayoutPanel2.AutoSize = true;
+            this.flowLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flowLayoutPanel2.Controls.Add(this.btnAdd);
+            this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 379);
+            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(169, 34);
+            this.flowLayoutPanel2.TabIndex = 1;
+            // 
+            // btnAdd
+            // 
+            this.btnAdd.AutoSize = true;
+            this.btnAdd.Location = new System.Drawing.Point(2, 2);
+            this.btnAdd.Margin = new System.Windows.Forms.Padding(2);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(168, 30);
+            this.btnAdd.TabIndex = 1;
+            this.btnAdd.Text = "&Add Teamtype";
+            this.btnAdd.UseVisualStyleBackColor = true;
+            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            // 
             // TeamTypesDialog
             // 
-            this.AcceptButton = this.btnOK;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(1313, 640);
+            this.ClientSize = new System.Drawing.Size(875, 416);
             this.ControlBox = false;
             this.Controls.Add(this.tableLayoutPanel1);
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "TeamTypesDialog";
@@ -661,6 +721,8 @@ namespace MobiusEditor.Dialogs
             ((System.ComponentModel.ISupportInitialize)(this.teamsDataGridView)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.missionsDataGridView)).EndInit();
             this.teamTypesContextMenuStrip.ResumeLayout(false);
+            this.flowLayoutPanel2.ResumeLayout(false);
+            this.flowLayoutPanel2.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -709,5 +771,7 @@ namespace MobiusEditor.Dialogs
         private System.Windows.Forms.DataGridViewTextBoxColumn teamsCountColumn;
         private System.Windows.Forms.DataGridViewComboBoxColumn missionsMissionColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn missionsArgumentColumn;
+        private FlowLayoutPanel flowLayoutPanel2;
+        private Button btnAdd;
     }
 }

--- a/CnCTDRAMapEditor/Dialogs/TriggersDialog.Designer.cs
+++ b/CnCTDRAMapEditor/Dialogs/TriggersDialog.Designer.cs
@@ -44,6 +44,8 @@ namespace MobiusEditor.Dialogs
         {
             this.components = new System.ComponentModel.Container();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.flowLayoutPanel2 = new System.Windows.Forms.FlowLayoutPanel();
+            this.btnAdd = new System.Windows.Forms.Button();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.btnCancel = new System.Windows.Forms.Button();
             this.btnOK = new System.Windows.Forms.Button();
@@ -83,6 +85,7 @@ namespace MobiusEditor.Dialogs
             this.addTriggerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.removeTriggerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tableLayoutPanel1.SuspendLayout();
+            this.flowLayoutPanel2.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.settingsPanel.SuspendLayout();
             this.triggersTableLayoutPanel.SuspendLayout();
@@ -102,6 +105,7 @@ namespace MobiusEditor.Dialogs
             this.tableLayoutPanel1.ColumnCount = 2;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel2, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.flowLayoutPanel1, 0, 1);
             this.tableLayoutPanel1.Controls.Add(this.settingsPanel, 1, 0);
             this.tableLayoutPanel1.Controls.Add(this.triggersListView, 0, 0);
@@ -112,31 +116,54 @@ namespace MobiusEditor.Dialogs
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.Size = new System.Drawing.Size(562, 499);
-            this.tableLayoutPanel1.TabIndex = 1;
+            this.tableLayoutPanel1.TabIndex = 2;
+            // 
+            // flowLayoutPanel2
+            // 
+            this.flowLayoutPanel2.AutoSize = true;
+            this.flowLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.flowLayoutPanel2.Controls.Add(this.btnAdd);
+            this.flowLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Left;
+            this.flowLayoutPanel2.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
+            this.flowLayoutPanel2.Location = new System.Drawing.Point(3, 462);
+            this.flowLayoutPanel2.Name = "flowLayoutPanel2";
+            this.flowLayoutPanel2.Size = new System.Drawing.Size(136, 34);
+            this.flowLayoutPanel2.TabIndex = 1;
+            // 
+            // btnAdd
+            // 
+            this.btnAdd.AutoSize = true;
+            this.btnAdd.Location = new System.Drawing.Point(2, 2);
+            this.btnAdd.Margin = new System.Windows.Forms.Padding(2);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(132, 30);
+            this.btnAdd.TabIndex = 1;
+            this.btnAdd.Text = "&Add Trigger";
+            this.btnAdd.UseVisualStyleBackColor = true;
+            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
             // 
             // flowLayoutPanel1
             // 
             this.flowLayoutPanel1.AutoSize = true;
             this.flowLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tableLayoutPanel1.SetColumnSpan(this.flowLayoutPanel1, 2);
             this.flowLayoutPanel1.Controls.Add(this.btnCancel);
             this.flowLayoutPanel1.Controls.Add(this.btnOK);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.flowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.RightToLeft;
-            this.flowLayoutPanel1.Location = new System.Drawing.Point(3, 462);
+            this.flowLayoutPanel1.Location = new System.Drawing.Point(145, 462);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(556, 34);
-            this.flowLayoutPanel1.TabIndex = 1;
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(414, 34);
+            this.flowLayoutPanel1.TabIndex = 3;
             // 
             // btnCancel
             // 
             this.btnCancel.AutoSize = true;
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(486, 2);
+            this.btnCancel.Location = new System.Drawing.Point(344, 2);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(2);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(68, 30);
-            this.btnCancel.TabIndex = 2;
+            this.btnCancel.TabIndex = 31;
             this.btnCancel.Text = "&Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             // 
@@ -144,11 +171,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.btnOK.AutoSize = true;
             this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.btnOK.Location = new System.Drawing.Point(432, 2);
+            this.btnOK.Location = new System.Drawing.Point(290, 2);
             this.btnOK.Margin = new System.Windows.Forms.Padding(2);
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(50, 30);
-            this.btnOK.TabIndex = 3;
+            this.btnOK.TabIndex = 30;
             this.btnOK.Text = "&OK";
             this.btnOK.UseVisualStyleBackColor = true;
             // 
@@ -156,11 +183,11 @@ namespace MobiusEditor.Dialogs
             // 
             this.settingsPanel.Controls.Add(this.triggersTableLayoutPanel);
             this.settingsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.settingsPanel.Location = new System.Drawing.Point(149, 10);
+            this.settingsPanel.Location = new System.Drawing.Point(152, 10);
             this.settingsPanel.Margin = new System.Windows.Forms.Padding(10);
             this.settingsPanel.Name = "settingsPanel";
-            this.settingsPanel.Size = new System.Drawing.Size(403, 439);
-            this.settingsPanel.TabIndex = 3;
+            this.settingsPanel.Size = new System.Drawing.Size(400, 439);
+            this.settingsPanel.TabIndex = 2;
             // 
             // triggersTableLayoutPanel
             // 
@@ -212,7 +239,7 @@ namespace MobiusEditor.Dialogs
             this.triggersTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.triggersTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.triggersTableLayoutPanel.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.triggersTableLayoutPanel.Size = new System.Drawing.Size(403, 439);
+            this.triggersTableLayoutPanel.Size = new System.Drawing.Size(400, 439);
             this.triggersTableLayoutPanel.TabIndex = 1;
             // 
             // label1
@@ -236,7 +263,7 @@ namespace MobiusEditor.Dialogs
             this.houseComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.houseComboBox.Name = "houseComboBox";
             this.houseComboBox.Size = new System.Drawing.Size(141, 21);
-            this.houseComboBox.TabIndex = 1;
+            this.houseComboBox.TabIndex = 10;
             // 
             // typeLabel
             // 
@@ -246,7 +273,7 @@ namespace MobiusEditor.Dialogs
             this.typeLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.typeLabel.Name = "typeLabel";
             this.typeLabel.Size = new System.Drawing.Size(67, 25);
-            this.typeLabel.TabIndex = 9;
+            this.typeLabel.TabIndex = 2;
             this.typeLabel.Text = "Type";
             this.typeLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -258,7 +285,7 @@ namespace MobiusEditor.Dialogs
             this.event1Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.event1Label.Name = "event1Label";
             this.event1Label.Size = new System.Drawing.Size(67, 57);
-            this.event1Label.TabIndex = 10;
+            this.event1Label.TabIndex = 3;
             this.event1Label.Text = "Event 1";
             this.event1Label.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -270,7 +297,7 @@ namespace MobiusEditor.Dialogs
             this.event2Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.event2Label.Name = "event2Label";
             this.event2Label.Size = new System.Drawing.Size(67, 57);
-            this.event2Label.TabIndex = 11;
+            this.event2Label.TabIndex = 4;
             this.event2Label.Text = "Event 2";
             this.event2Label.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -282,7 +309,7 @@ namespace MobiusEditor.Dialogs
             this.action1Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.action1Label.Name = "action1Label";
             this.action1Label.Size = new System.Drawing.Size(67, 57);
-            this.action1Label.TabIndex = 15;
+            this.action1Label.TabIndex = 5;
             this.action1Label.Text = "Action 1";
             this.action1Label.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -294,7 +321,7 @@ namespace MobiusEditor.Dialogs
             this.action2Label.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.action2Label.Name = "action2Label";
             this.action2Label.Size = new System.Drawing.Size(67, 57);
-            this.action2Label.TabIndex = 16;
+            this.action2Label.TabIndex = 6;
             this.action2Label.Text = "Action 2";
             this.action2Label.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -319,7 +346,7 @@ namespace MobiusEditor.Dialogs
             this.action2ComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.action2ComboBox.Name = "action2ComboBox";
             this.action2ComboBox.Size = new System.Drawing.Size(141, 21);
-            this.action2ComboBox.TabIndex = 18;
+            this.action2ComboBox.TabIndex = 19;
             this.action2ComboBox.SelectedIndexChanged += new System.EventHandler(this.trigger2ComboBox_SelectedIndexChanged);
             // 
             // existenceLabel
@@ -329,7 +356,7 @@ namespace MobiusEditor.Dialogs
             this.existenceLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.existenceLabel.Name = "existenceLabel";
             this.existenceLabel.Size = new System.Drawing.Size(67, 25);
-            this.existenceLabel.TabIndex = 19;
+            this.existenceLabel.TabIndex = 1;
             this.existenceLabel.Text = "Existence";
             this.existenceLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -343,7 +370,7 @@ namespace MobiusEditor.Dialogs
             this.existenceComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.existenceComboBox.Name = "existenceComboBox";
             this.existenceComboBox.Size = new System.Drawing.Size(141, 21);
-            this.existenceComboBox.TabIndex = 20;
+            this.existenceComboBox.TabIndex = 11;
             this.existenceComboBox.ValueMember = "Value";
             // 
             // typeComboBox
@@ -356,7 +383,7 @@ namespace MobiusEditor.Dialogs
             this.typeComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.typeComboBox.Name = "typeComboBox";
             this.typeComboBox.Size = new System.Drawing.Size(141, 21);
-            this.typeComboBox.TabIndex = 21;
+            this.typeComboBox.TabIndex = 12;
             this.typeComboBox.ValueMember = "Value";
             this.typeComboBox.SelectedValueChanged += new System.EventHandler(this.typeComboBox_SelectedValueChanged);
             // 
@@ -369,7 +396,7 @@ namespace MobiusEditor.Dialogs
             this.event1ComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.event1ComboBox.Name = "event1ComboBox";
             this.event1ComboBox.Size = new System.Drawing.Size(141, 21);
-            this.event1ComboBox.TabIndex = 22;
+            this.event1ComboBox.TabIndex = 13;
             this.event1ComboBox.SelectedIndexChanged += new System.EventHandler(this.trigger1ComboBox_SelectedIndexChanged);
             // 
             // event2ComboBox
@@ -381,7 +408,7 @@ namespace MobiusEditor.Dialogs
             this.event2ComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.event2ComboBox.Name = "event2ComboBox";
             this.event2ComboBox.Size = new System.Drawing.Size(141, 21);
-            this.event2ComboBox.TabIndex = 23;
+            this.event2ComboBox.TabIndex = 15;
             this.event2ComboBox.SelectedIndexChanged += new System.EventHandler(this.trigger2ComboBox_SelectedIndexChanged);
             // 
             // teamLabel
@@ -391,7 +418,7 @@ namespace MobiusEditor.Dialogs
             this.teamLabel.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.teamLabel.Name = "teamLabel";
             this.teamLabel.Size = new System.Drawing.Size(67, 25);
-            this.teamLabel.TabIndex = 32;
+            this.teamLabel.TabIndex = 7;
             this.teamLabel.Text = "Team";
             this.teamLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -404,7 +431,7 @@ namespace MobiusEditor.Dialogs
             this.teamComboBox.Margin = new System.Windows.Forms.Padding(2);
             this.teamComboBox.Name = "teamComboBox";
             this.teamComboBox.Size = new System.Drawing.Size(141, 21);
-            this.teamComboBox.TabIndex = 33;
+            this.teamComboBox.TabIndex = 21;
             // 
             // event1Flp
             // 
@@ -416,7 +443,7 @@ namespace MobiusEditor.Dialogs
             this.event1Flp.Location = new System.Drawing.Point(219, 78);
             this.event1Flp.Name = "event1Flp";
             this.event1Flp.Size = new System.Drawing.Size(172, 51);
-            this.event1Flp.TabIndex = 36;
+            this.event1Flp.TabIndex = 14;
             // 
             // event1Nud
             // 
@@ -434,7 +461,7 @@ namespace MobiusEditor.Dialogs
             -2147483648});
             this.event1Nud.Name = "event1Nud";
             this.event1Nud.Size = new System.Drawing.Size(70, 20);
-            this.event1Nud.TabIndex = 31;
+            this.event1Nud.TabIndex = 0;
             // 
             // event1ValueComboBox
             // 
@@ -443,7 +470,7 @@ namespace MobiusEditor.Dialogs
             this.event1ValueComboBox.Location = new System.Drawing.Point(3, 27);
             this.event1ValueComboBox.Name = "event1ValueComboBox";
             this.event1ValueComboBox.Size = new System.Drawing.Size(166, 21);
-            this.event1ValueComboBox.TabIndex = 32;
+            this.event1ValueComboBox.TabIndex = 1;
             // 
             // event2Flp
             // 
@@ -454,7 +481,7 @@ namespace MobiusEditor.Dialogs
             this.event2Flp.Location = new System.Drawing.Point(219, 135);
             this.event2Flp.Name = "event2Flp";
             this.event2Flp.Size = new System.Drawing.Size(172, 51);
-            this.event2Flp.TabIndex = 37;
+            this.event2Flp.TabIndex = 16;
             // 
             // event2Nud
             // 
@@ -472,7 +499,7 @@ namespace MobiusEditor.Dialogs
             -2147483648});
             this.event2Nud.Name = "event2Nud";
             this.event2Nud.Size = new System.Drawing.Size(70, 20);
-            this.event2Nud.TabIndex = 30;
+            this.event2Nud.TabIndex = 0;
             // 
             // event2ValueComboBox
             // 
@@ -481,7 +508,7 @@ namespace MobiusEditor.Dialogs
             this.event2ValueComboBox.Location = new System.Drawing.Point(3, 27);
             this.event2ValueComboBox.Name = "event2ValueComboBox";
             this.event2ValueComboBox.Size = new System.Drawing.Size(166, 21);
-            this.event2ValueComboBox.TabIndex = 33;
+            this.event2ValueComboBox.TabIndex = 1;
             // 
             // action1Flp
             // 
@@ -492,7 +519,7 @@ namespace MobiusEditor.Dialogs
             this.action1Flp.Location = new System.Drawing.Point(219, 192);
             this.action1Flp.Name = "action1Flp";
             this.action1Flp.Size = new System.Drawing.Size(172, 51);
-            this.action1Flp.TabIndex = 38;
+            this.action1Flp.TabIndex = 18;
             // 
             // action1Nud
             // 
@@ -510,7 +537,7 @@ namespace MobiusEditor.Dialogs
             -2147483648});
             this.action1Nud.Name = "action1Nud";
             this.action1Nud.Size = new System.Drawing.Size(70, 20);
-            this.action1Nud.TabIndex = 31;
+            this.action1Nud.TabIndex = 0;
             // 
             // action1ValueComboBox
             // 
@@ -519,7 +546,7 @@ namespace MobiusEditor.Dialogs
             this.action1ValueComboBox.Location = new System.Drawing.Point(3, 27);
             this.action1ValueComboBox.Name = "action1ValueComboBox";
             this.action1ValueComboBox.Size = new System.Drawing.Size(166, 21);
-            this.action1ValueComboBox.TabIndex = 33;
+            this.action1ValueComboBox.TabIndex = 1;
             // 
             // action2Flp
             // 
@@ -530,7 +557,7 @@ namespace MobiusEditor.Dialogs
             this.action2Flp.Location = new System.Drawing.Point(219, 249);
             this.action2Flp.Name = "action2Flp";
             this.action2Flp.Size = new System.Drawing.Size(172, 51);
-            this.action2Flp.TabIndex = 39;
+            this.action2Flp.TabIndex = 20;
             // 
             // action2Nud
             // 
@@ -548,7 +575,7 @@ namespace MobiusEditor.Dialogs
             -2147483648});
             this.action2Nud.Name = "action2Nud";
             this.action2Nud.Size = new System.Drawing.Size(70, 20);
-            this.action2Nud.TabIndex = 32;
+            this.action2Nud.TabIndex = 0;
             // 
             // action2ValueComboBox
             // 
@@ -557,7 +584,7 @@ namespace MobiusEditor.Dialogs
             this.action2ValueComboBox.Location = new System.Drawing.Point(3, 27);
             this.action2ValueComboBox.Name = "action2ValueComboBox";
             this.action2ValueComboBox.Size = new System.Drawing.Size(166, 21);
-            this.action2ValueComboBox.TabIndex = 33;
+            this.action2ValueComboBox.TabIndex = 1;
             // 
             // triggersListView
             // 
@@ -572,8 +599,8 @@ namespace MobiusEditor.Dialogs
             this.triggersListView.MultiSelect = false;
             this.triggersListView.Name = "triggersListView";
             this.triggersListView.ShowItemToolTips = true;
-            this.triggersListView.Size = new System.Drawing.Size(135, 455);
-            this.triggersListView.TabIndex = 4;
+            this.triggersListView.Size = new System.Drawing.Size(138, 455);
+            this.triggersListView.TabIndex = 0;
             this.triggersListView.UseCompatibleStateImageBehavior = false;
             this.triggersListView.View = System.Windows.Forms.View.Details;
             this.triggersListView.AfterLabelEdit += new System.Windows.Forms.LabelEditEventHandler(this.teamTypesListView_AfterLabelEdit);
@@ -588,25 +615,24 @@ namespace MobiusEditor.Dialogs
             this.addTriggerToolStripMenuItem,
             this.removeTriggerToolStripMenuItem});
             this.triggersContextMenuStrip.Name = "teamTypesContextMenuStrip";
-            this.triggersContextMenuStrip.Size = new System.Drawing.Size(157, 48);
+            this.triggersContextMenuStrip.Size = new System.Drawing.Size(159, 48);
             // 
             // addTriggerToolStripMenuItem
             // 
             this.addTriggerToolStripMenuItem.Name = "addTriggerToolStripMenuItem";
-            this.addTriggerToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
+            this.addTriggerToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
             this.addTriggerToolStripMenuItem.Text = "&Add Trigger";
             this.addTriggerToolStripMenuItem.Click += new System.EventHandler(this.addTriggerToolStripMenuItem_Click);
             // 
             // removeTriggerToolStripMenuItem
             // 
             this.removeTriggerToolStripMenuItem.Name = "removeTriggerToolStripMenuItem";
-            this.removeTriggerToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
+            this.removeTriggerToolStripMenuItem.Size = new System.Drawing.Size(158, 22);
             this.removeTriggerToolStripMenuItem.Text = "&Remove Trigger";
             this.removeTriggerToolStripMenuItem.Click += new System.EventHandler(this.removeTriggerToolStripMenuItem_Click);
             // 
             // TriggersDialog
             // 
-            this.AcceptButton = this.btnOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
@@ -623,6 +649,8 @@ namespace MobiusEditor.Dialogs
             this.Text = "Triggers";
             this.tableLayoutPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.PerformLayout();
+            this.flowLayoutPanel2.ResumeLayout(false);
+            this.flowLayoutPanel2.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.PerformLayout();
             this.settingsPanel.ResumeLayout(false);
@@ -683,5 +711,7 @@ namespace MobiusEditor.Dialogs
         private System.Windows.Forms.ComboBox event2ValueComboBox;
         private System.Windows.Forms.ComboBox action1ValueComboBox;
         private System.Windows.Forms.ComboBox action2ValueComboBox;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel2;
+        private System.Windows.Forms.Button btnAdd;
     }
 }

--- a/CnCTDRAMapEditor/Dialogs/TriggersDialog.cs
+++ b/CnCTDRAMapEditor/Dialogs/TriggersDialog.cs
@@ -72,7 +72,7 @@ namespace MobiusEditor.Dialogs
             }
             triggersListView.EndUpdate();
 
-            string[] existenceNames = Enum.GetNames(typeof(TriggerPersistantType));
+            string[] existenceNames = Enum.GetNames(typeof(TriggerPersistentType));
             switch (plugin.GameType)
             {
                 case GameType.TiberianDawn:
@@ -92,8 +92,8 @@ namespace MobiusEditor.Dialogs
             };
 
             houseComboBox.DataSource = "None".Yield().Concat(plugin.Map.Houses.Select(t => t.Type.Name)).ToArray();
-            existenceComboBox.DataSource = Enum.GetValues(typeof(TriggerPersistantType)).Cast<int>()
-                .Select(v => new { Name = existenceNames[v], Value = (TriggerPersistantType)v })
+            existenceComboBox.DataSource = Enum.GetValues(typeof(TriggerPersistentType)).Cast<int>()
+                .Select(v => new { Name = existenceNames[v], Value = (TriggerPersistentType)v })
                 .ToArray();
             typeComboBox.DataSource = Enum.GetValues(typeof(TriggerMultiStyleType)).Cast<int>()
                 .Select(v => new { Name = typeNames[v], Value = (TriggerMultiStyleType)v })
@@ -121,7 +121,7 @@ namespace MobiusEditor.Dialogs
             if (SelectedTrigger != null)
             {
                 houseComboBox.DataBindings.Add("SelectedItem", SelectedTrigger, "House");
-                existenceComboBox.DataBindings.Add("SelectedValue", SelectedTrigger, "PersistantType");
+                existenceComboBox.DataBindings.Add("SelectedValue", SelectedTrigger, "PersistentType");
                 event1ComboBox.DataBindings.Add("SelectedItem", SelectedTrigger.Event1, "EventType");
                 action1ComboBox.DataBindings.Add("SelectedItem", SelectedTrigger.Action1, "ActionType");
 
@@ -182,6 +182,16 @@ namespace MobiusEditor.Dialogs
 
         private void addTriggerToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            AddTrigger();
+        }
+
+        private void btnAdd_Click(object sender, EventArgs e)
+        {
+            AddTrigger();
+        }
+
+        private void AddTrigger()
+        {
             var nameChars = Enumerable.Range(97, 26).Concat(Enumerable.Range(48, 10));
 
             string name = string.Empty;
@@ -240,7 +250,7 @@ namespace MobiusEditor.Dialogs
             else if (triggers.Where(t => (t != SelectedTrigger) && t.Equals(e.Label)).Any())
             {
                 e.CancelEdit = true;
-                MessageBox.Show(string.Format("Trigger with name '{0]' already exists", e.Label), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show(string.Format("Trigger with name '{0}' already exists", e.Label), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             else
             {
@@ -322,6 +332,7 @@ namespace MobiusEditor.Dialogs
                             case RedAlert.EventTypes.TEVENT_CROSS_VERTICAL:
                             case RedAlert.EventTypes.TEVENT_ENTERS_ZONE:
                             case RedAlert.EventTypes.TEVENT_LOW_POWER:
+                            case RedAlert.EventTypes.TEVENT_SPIED:
                             case RedAlert.EventTypes.TEVENT_THIEVED:
                             case RedAlert.EventTypes.TEVENT_HOUSE_DISCOVERED:
                             case RedAlert.EventTypes.TEVENT_BUILDINGS_DESTROYED:

--- a/CnCTDRAMapEditor/GameInstallationPathForm.cs
+++ b/CnCTDRAMapEditor/GameInstallationPathForm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Security;
 using System.Windows.Forms;
 
 namespace MobiusEditor
@@ -31,7 +32,21 @@ namespace MobiusEditor
 
         private void btnContinue_Click(object sender, EventArgs e)
         {
-            if (!File.Exists(Path.Combine(Path.GetDirectoryName(textBox1.Text), "DATA", "CONFIG.MEG")))
+            String dir = textBox1.Text;
+            Boolean checkPassed = false;
+            try
+            {
+                if ((new FileInfo(dir).Attributes & FileAttributes.Directory) != 0)
+                    dir = dir.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+                String fileToCheck = Path.Combine(Path.GetDirectoryName(dir), "DATA", "CONFIG.MEG");
+                checkPassed = File.Exists(fileToCheck);
+            }
+            catch (SecurityException) { /* Check not passed */}
+            catch (ArgumentException) { /* Check not passed */}
+            catch (UnauthorizedAccessException) { /* Check not passed */}
+            catch (PathTooLongException) { /* Check not passed */}
+            catch (NotSupportedException) { /* Check not passed */}
+            if (!checkPassed)
             {
                 MessageBox.Show("Required data is missing, please enter the valid " +
                     "installation path for the C&C Remastered Collection. The " +
@@ -39,7 +54,7 @@ namespace MobiusEditor
                     "collection (ClientG.exe and ClientLauncherG.exe) reside.", "Invalid directory");
                 return;
             }
-
+            textBox1.Text = dir;
             DialogResult = DialogResult.OK;
             Close();
         }

--- a/CnCTDRAMapEditor/MainForm.Designer.cs
+++ b/CnCTDRAMapEditor/MainForm.Designer.cs
@@ -140,6 +140,7 @@ namespace MobiusEditor
             // fileNewMenuItem
             // 
             this.fileNewMenuItem.Name = "fileNewMenuItem";
+            this.fileNewMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
             this.fileNewMenuItem.Size = new System.Drawing.Size(162, 26);
             this.fileNewMenuItem.Text = "&New...";
             this.fileNewMenuItem.Click += new System.EventHandler(this.fileNewMenuItem_Click);
@@ -147,6 +148,7 @@ namespace MobiusEditor
             // fileOpenMenuItem
             // 
             this.fileOpenMenuItem.Name = "fileOpenMenuItem";
+            this.fileOpenMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
             this.fileOpenMenuItem.Size = new System.Drawing.Size(162, 26);
             this.fileOpenMenuItem.Text = "&Open...";
             this.fileOpenMenuItem.Click += new System.EventHandler(this.fileOpenMenuItem_Click);
@@ -154,6 +156,7 @@ namespace MobiusEditor
             // fileSaveMenuItem
             // 
             this.fileSaveMenuItem.Name = "fileSaveMenuItem";
+            this.fileSaveMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
             this.fileSaveMenuItem.Size = new System.Drawing.Size(162, 26);
             this.fileSaveMenuItem.Text = "&Save";
             this.fileSaveMenuItem.Click += new System.EventHandler(this.fileSaveMenuItem_Click);
@@ -161,6 +164,7 @@ namespace MobiusEditor
             // fileSaveAsMenuItem
             // 
             this.fileSaveAsMenuItem.Name = "fileSaveAsMenuItem";
+            this.fileSaveAsMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift | System.Windows.Forms.Keys.S)));
             this.fileSaveAsMenuItem.Size = new System.Drawing.Size(162, 26);
             this.fileSaveAsMenuItem.Text = "Save &As...";
             this.fileSaveAsMenuItem.Click += new System.EventHandler(this.fileSaveAsMenuItem_Click);
@@ -173,6 +177,7 @@ namespace MobiusEditor
             // fileExportMenuItem
             // 
             this.fileExportMenuItem.Name = "fileExportMenuItem";
+            this.fileExportMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.E)));
             this.fileExportMenuItem.Size = new System.Drawing.Size(162, 26);
             this.fileExportMenuItem.Text = "&Export...";
             this.fileExportMenuItem.Click += new System.EventHandler(this.fileExportMenuItem_Click);
@@ -180,6 +185,7 @@ namespace MobiusEditor
             // filePublishMenuItem
             // 
             this.filePublishMenuItem.Name = "filePublishMenuItem";
+            this.filePublishMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
             this.filePublishMenuItem.Size = new System.Drawing.Size(162, 26);
             this.filePublishMenuItem.Text = "&Publish...";
             this.filePublishMenuItem.Click += new System.EventHandler(this.filePublishMenuItem_Click);

--- a/CnCTDRAMapEditor/MainForm.cs
+++ b/CnCTDRAMapEditor/MainForm.cs
@@ -335,11 +335,11 @@ namespace MobiusEditor
                 switch (plugin.GameType)
                 {
                     case GameType.TiberianDawn:
-                        ofd.InitialDirectory = TiberianDawn.Constants.SaveDirectory;
+                        ofd.InitialDirectory = Path.GetDirectoryName(filename) ?? TiberianDawn.Constants.SaveDirectory;
                         ofd.FilterIndex = 1;
                         break;
                     case GameType.RedAlert:
-                        ofd.InitialDirectory = RedAlert.Constants.SaveDirectory;
+                        ofd.InitialDirectory = Path.GetDirectoryName(filename) ?? RedAlert.Constants.SaveDirectory;
                         ofd.FilterIndex = 2;
                         break;
                 }
@@ -674,7 +674,7 @@ namespace MobiusEditor
                         sb.AppendFormat(", Unit = {0}", unitType.DisplayName);
                     }
 
-                    var building = plugin.Map.Technos[location] as Building;
+                    var building = plugin.Map.Buildings[location] as Building;
                     var buildingType = building?.Type;
                     if (buildingType != null)
                     {

--- a/CnCTDRAMapEditor/Model/BuildingType.cs
+++ b/CnCTDRAMapEditor/Model/BuildingType.cs
@@ -143,6 +143,7 @@ namespace MobiusEditor.Model
 
         public void Init(GameType gameType, TheaterType theater, HouseType house, DirectionType direction)
         {
+            var oldImage = Thumbnail;
             var mockBuilding = new Building()
             {
                 Type = this,
@@ -160,6 +161,15 @@ namespace MobiusEditor.Model
                     render.Item2(g);
                 }
                 Thumbnail = buildingPreview;
+            }
+            else
+            {
+                Thumbnail = null;
+            }
+            if (oldImage != null)
+            {
+                try { oldImage.Dispose(); }
+                catch { /* ignore */ }
             }
         }
     }

--- a/CnCTDRAMapEditor/Model/CellGrid.cs
+++ b/CnCTDRAMapEditor/Model/CellGrid.cs
@@ -102,6 +102,20 @@ namespace MobiusEditor.Model
             OnCleared();
         }
 
+        public int CellNumberOf(T obj)
+        {
+            for (int y = 0; y < metrics.Height; ++y)
+            {
+                for (int x = 0; x < metrics.Width; ++x)
+                {
+                    if (cells[y, x].Equals(obj))
+                        return y * metrics.Width + x;
+                }
+            }
+            return -1;
+        }
+
+
         public T Adjacent(Point location, FacingType facing)
         {
             return metrics.Adjacent(location, facing, out Point adjacent) ? this[adjacent] : default;

--- a/CnCTDRAMapEditor/Model/InfantryType.cs
+++ b/CnCTDRAMapEditor/Model/InfantryType.cs
@@ -77,6 +77,7 @@ namespace MobiusEditor.Model
 
         public void Init(GameType gameType, TheaterType theater, HouseType house, DirectionType direction)
         {
+            var oldImage = Thumbnail;
             if (Globals.TheTilesetManager.GetTileData(theater.Tilesets, Name, 4, out Tile tile))
             {
                 RenderSize = new Size(tile.Image.Width / Globals.TileScale, tile.Image.Height / Globals.TileScale);
@@ -95,6 +96,11 @@ namespace MobiusEditor.Model
                 MapRenderer.Render(theater, Point.Empty, Globals.TileSize, mockInfantry, InfantryStoppingType.Center).Item2(g);
             }
             Thumbnail = infantryThumbnail;
+            if (oldImage != null)
+            {
+                try { oldImage.Dispose(); }
+                catch { /* ignore */ }
+            }
         }
     }
 }

--- a/CnCTDRAMapEditor/Model/Map.cs
+++ b/CnCTDRAMapEditor/Model/Map.cs
@@ -141,6 +141,8 @@ namespace MobiusEditor.Model
 
         public readonly List<BuildingType> BuildingTypes;
 
+        public readonly List<ITechnoType> TeamTechnoTypes;
+
         public readonly string[] TeamMissionTypes;
 
         public readonly CellMetrics Metrics;
@@ -194,7 +196,8 @@ namespace MobiusEditor.Model
             IEnumerable<TerrainType> terrainTypes, IEnumerable<OverlayType> overlayTypes, IEnumerable<SmudgeType> smudgeTypes,
             IEnumerable<string> eventTypes, IEnumerable<string> actionTypes, IEnumerable<string> missionTypes,
             IEnumerable<DirectionType> directionTypes, IEnumerable<InfantryType> infantryTypes, IEnumerable<UnitType> unitTypes,
-            IEnumerable<BuildingType> buildingTypes, IEnumerable<string> teamMissionTypes, IEnumerable<Waypoint> waypoints,
+            IEnumerable<BuildingType> buildingTypes, IEnumerable<string> teamMissionTypes, IEnumerable<ITechnoType> teamTechnoTypes,
+            IEnumerable<Waypoint> waypoints,
             IEnumerable<string> movieTypes)
         {
             BasicSection = basicSection;
@@ -214,6 +217,7 @@ namespace MobiusEditor.Model
             UnitTypes = new List<UnitType>(unitTypes);
             BuildingTypes = new List<BuildingType>(buildingTypes);
             TeamMissionTypes = teamMissionTypes.ToArray();
+            TeamTechnoTypes = new List<ITechnoType>(teamTechnoTypes);
             MovieTypes = new List<string>(movieTypes);
 
             Metrics = new CellMetrics(cellSize);
@@ -432,7 +436,6 @@ namespace MobiusEditor.Model
                             {
                                 Type = bibType,
                                 Icon = icon,
-                                Data = 0,
                                 Tint = building.Tint
                             };
                             building.BibCells.Add(subCell);
@@ -447,7 +450,7 @@ namespace MobiusEditor.Model
             var map = new Map(BasicSection, Theater, Metrics.Size, HouseType,
                 HouseTypes, TheaterTypes, TemplateTypes, TerrainTypes, OverlayTypes, SmudgeTypes,
                 EventTypes, ActionTypes, MissionTypes, DirectionTypes, InfantryTypes, UnitTypes,
-                BuildingTypes, TeamMissionTypes, Waypoints, MovieTypes)
+                BuildingTypes, TeamMissionTypes, TeamTechnoTypes, Waypoints, MovieTypes)
             {
                 TopLeft = TopLeft,
                 Size = Size
@@ -526,13 +529,10 @@ namespace MobiusEditor.Model
                     g.DrawImage(fullBitmap, new Rectangle(0, 0, mapBounds.Width, mapBounds.Height), mapBounds, GraphicsUnit.Pixel);
                 }
 
-                fullBitmap.Dispose();
-
                 if (sharpen)
                 {
                     using (var sharpenedImage = croppedBitmap.Sharpen(1.0f))
                     {
-                        croppedBitmap.Dispose();
                         return TGA.FromBitmap(sharpenedImage);
                     }
                 }

--- a/CnCTDRAMapEditor/Model/OverlayType.cs
+++ b/CnCTDRAMapEditor/Model/OverlayType.cs
@@ -22,12 +22,14 @@ namespace MobiusEditor.Model
     [Flags]
     public enum OverlayTypeFlag
     {
+        // Nyerguds upgrade: Added decoration type.
         None            = 0,
         TiberiumOrGold  = (1 << 0),
         Gems            = (1 << 1),
         Wall            = (1 << 2),
         Crate           = (1 << 3),
         Flag            = (1 << 4),
+        Decoration      = (1 << 5),
     }
 
     public class OverlayType : ICellOccupier, IBrowsableType
@@ -58,7 +60,8 @@ namespace MobiusEditor.Model
 
         public bool IsFlag => (Flag & OverlayTypeFlag.Flag) != OverlayTypeFlag.None;
 
-        public bool IsPlaceable => (Flag & ~OverlayTypeFlag.Crate) == OverlayTypeFlag.None;
+         // No reason not to allow placing decorations and flag pedestal.
+        public bool IsPlaceable => (Flag & (OverlayTypeFlag.Crate | OverlayTypeFlag.Decoration | OverlayTypeFlag.Flag)) != OverlayTypeFlag.None;
 
         public OverlayType(sbyte id, string name, string textId, TheaterType[] theaters, OverlayTypeFlag flag)
         {
@@ -75,7 +78,7 @@ namespace MobiusEditor.Model
         }
 
         public OverlayType(sbyte id, string name, string textId, TheaterType[] theaters)
-            : this(id, name, textId, theaters, OverlayTypeFlag.None)
+            : this(id, name, textId, theaters, OverlayTypeFlag.Decoration)
         {
         }
 
@@ -119,9 +122,19 @@ namespace MobiusEditor.Model
 
         public void Init(TheaterType theater)
         {
+            var oldImage = Thumbnail;
             if (Globals.TheTilesetManager.GetTileData(theater.Tilesets, Name, 0, out Tile tile))
             {
-                Thumbnail = new Bitmap(tile.Image, tile.Image.Width, tile.Image.Height);
+                Thumbnail = new Bitmap(tile.Image);
+            }
+            else
+            {
+                Thumbnail = SystemIcons.Error.ToBitmap();
+            }
+            if (oldImage != null)
+            {
+                try { oldImage.Dispose(); }
+                catch { /* ignore */ }
             }
         }
     }

--- a/CnCTDRAMapEditor/Model/Smudge.cs
+++ b/CnCTDRAMapEditor/Model/Smudge.cs
@@ -12,18 +12,49 @@
 // distributed with this program. You should have received a copy of the 
 // GNU General Public License along with permitted additional restrictions 
 // with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+using MobiusEditor.Interface;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
+using System.Runtime.CompilerServices;
 
 namespace MobiusEditor.Model
 {
-    public class Smudge
+    public class Smudge: ICellOverlapper, INotifyPropertyChanged, ICloneable
     {
-        public SmudgeType Type { get; set; }
+        public event PropertyChangedEventHandler PropertyChanged;
+        private SmudgeType type;
+        public SmudgeType Type { get => type; set => SetField(ref type, value); }
 
-        public int Icon { get; set; }
-
-        public int Data { get; set; }
+        private int icon;
+        public int Icon { get => icon; set => SetField(ref icon, value); }
 
         public Color Tint { get; set; } = Color.White;
+
+        public Rectangle OverlapBounds => new Rectangle(Point.Empty, Type.Size);
+
+        protected bool SetField<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (EqualityComparer<T>.Default.Equals(field, value))
+            {
+                return false;
+            }
+            field = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        public object Clone()
+        {
+            return new Smudge()
+            {
+                Type = Type,
+                Icon = Icon,
+                Tint = Tint
+            };
+        }
     }
 }

--- a/CnCTDRAMapEditor/Model/SmudgeType.cs
+++ b/CnCTDRAMapEditor/Model/SmudgeType.cs
@@ -23,10 +23,11 @@ namespace MobiusEditor.Model
     public enum SmudgeTypeFlag
     {
         None = 0,
-        Bib = 1,
-        Bib1 = 3,
-        Bib2 = 5,
-        Bib3 = 9,
+        // Only used for the bibs automatically added under buildings.
+        Bib = 1 << 3,
+        Bib1 = 0 | Bib,
+        Bib2 = 1 | Bib,
+        Bib3 = 2 | Bib,
     }
 
     public class SmudgeType : IBrowsableType
@@ -38,6 +39,7 @@ namespace MobiusEditor.Model
         public string DisplayName => Name;
 
         public Size Size { get; set; }
+        public int Icons{ get; set; }
 
         public SmudgeTypeFlag Flag { get; private set; }
 
@@ -45,23 +47,40 @@ namespace MobiusEditor.Model
 
         public Image Thumbnail { get; set; }
 
-        public SmudgeType(sbyte id, string name, Size size, SmudgeTypeFlag flag)
+        public SmudgeType(sbyte id, string name)
+            :this(id, name, new Size(1, 1), 1, SmudgeTypeFlag.None)
         {
-            ID = id;
-            Name = name;
-            Size = size;
-            Flag = flag;
+        }
+        public SmudgeType(sbyte id, string name, int icons)
+            :this(id, name, new Size(1, 1), icons, SmudgeTypeFlag.None)
+        {
         }
 
+
+        public SmudgeType(sbyte id, string name, Size size, SmudgeTypeFlag flag)
+            : this(id, name, size, 1, flag)
+        {
+        }
+        
         public SmudgeType(sbyte id, string name, Size size)
             : this(id, name, size, SmudgeTypeFlag.None)
         {
         }
 
-        public SmudgeType(sbyte id, string name)
-            : this(id, name, new Size(1, 1), SmudgeTypeFlag.None)
+        public SmudgeType(sbyte id, string name, SmudgeTypeFlag type)
+            : this(id, name, new Size(1, 1), type)
         {
         }
+
+        public SmudgeType(sbyte id, string name, Size size, int icons, SmudgeTypeFlag flag)
+        {
+            ID = id;
+            Name = name;
+            Size = size;
+            Icons = icons;
+            Flag = flag;
+        }
+
 
         public override bool Equals(object obj)
         {
@@ -93,6 +112,7 @@ namespace MobiusEditor.Model
 
         public void Init(TheaterType theater)
         {
+            var oldImage = Thumbnail;
             if (Globals.TheTilesetManager.GetTileData(theater.Tilesets, Name, 0, out Tile tile))
             {
                 if ((tile.Image.Width * Globals.TileHeight) > (tile.Image.Height * Globals.TileWidth))
@@ -110,6 +130,15 @@ namespace MobiusEditor.Model
                     );
                 }
                 Thumbnail = new Bitmap(tile.Image, tile.Image.Width, tile.Image.Height);
+            }
+            else
+            {
+                Thumbnail = null;
+            }
+            if (oldImage != null)
+            {
+                try { oldImage.Dispose(); }
+                catch { /* ignore */ }
             }
         }
     }

--- a/CnCTDRAMapEditor/Model/TeamType.cs
+++ b/CnCTDRAMapEditor/Model/TeamType.cs
@@ -126,6 +126,26 @@ namespace MobiusEditor.Model
             return teamType;
         }
 
+        public Boolean IsEmpty() {
+            // true if nothing is filled in besides a default selected house.
+            return
+                IsRoundAbout == false
+                && IsLearning == false
+                && IsSuicide == false
+                && IsAutocreate == false
+                && IsMercenary == false
+                && RecruitPriority == 0
+                && MaxAllowed == 0
+                && InitNum == 0
+                && Fear == 0
+                && IsReinforcable == false
+                && IsPrebuilt == false
+                && Origin == 0
+                && Trigger == null
+                && Classes.Count == 0
+                && Missions.Count == 0;
+        }
+
         public override bool Equals(object obj)
         {
             if (obj is TeamType)

--- a/CnCTDRAMapEditor/Model/TemplateType.cs
+++ b/CnCTDRAMapEditor/Model/TemplateType.cs
@@ -101,6 +101,7 @@ namespace MobiusEditor.Model
 
         public void Init(TheaterType theater)
         {
+            var oldImage = Thumbnail;
             var size = new Size(Globals.OriginalTileWidth / 4, Globals.OriginalTileWidth / 4);
             var iconSize = Math.Max(IconWidth, IconHeight);
             var thumbnail = new Bitmap(iconSize * size.Width, iconSize * size.Height);
@@ -125,9 +126,18 @@ namespace MobiusEditor.Model
                     }
                 }
             }
-
+            if (!found)
+            {
+                try { thumbnail.Dispose(); }
+                catch { /* ignore */ }
+            }
             Thumbnail = found ? thumbnail : null;
             IconMask = mask;
+            if (oldImage != null)
+            {
+                try { oldImage.Dispose(); }
+                catch { /* ignore */ }
+            }
         }
     }
 }

--- a/CnCTDRAMapEditor/Model/TerrainType.cs
+++ b/CnCTDRAMapEditor/Model/TerrainType.cs
@@ -101,6 +101,7 @@ namespace MobiusEditor.Model
 
         public void Init(TheaterType theater)
         {
+            var oldImage = Thumbnail;
             string tileName = Name;
             if ((TemplateType & TemplateTypeFlag.OreMine) != TemplateTypeFlag.None)
             {
@@ -111,6 +112,15 @@ namespace MobiusEditor.Model
             {
                 RenderSize = new Size(tile.Image.Width / Globals.TileScale, tile.Image.Height / Globals.TileScale);
                 Thumbnail = new Bitmap(tile.Image, tile.Image.Width / 2, tile.Image.Height / 2);
+            }
+            else
+            {
+                Thumbnail = null;
+            }
+            if (oldImage != null)
+            {
+                try { oldImage.Dispose(); }
+                catch { /* ignore */ }
             }
         }
     }

--- a/CnCTDRAMapEditor/Model/Trigger.cs
+++ b/CnCTDRAMapEditor/Model/Trigger.cs
@@ -17,11 +17,11 @@ using System;
 
 namespace MobiusEditor.Model
 {
-    public enum TriggerPersistantType
+    public enum TriggerPersistentType
     {
         Volatile = 0,
-        SemiPersistant = 1,
-        Persistant = 2
+        SemiPersistent = 1,
+        Persistent = 2
     }
 
     public enum TriggerMultiStyleType
@@ -93,7 +93,7 @@ namespace MobiusEditor.Model
 
         public string Name { get; set; }
 
-        public TriggerPersistantType PersistantType { get; set; } = TriggerPersistantType.Volatile;
+        public TriggerPersistentType PersistentType { get; set; } = TriggerPersistentType.Volatile;
 
         public string House { get; set; }
 
@@ -112,7 +112,7 @@ namespace MobiusEditor.Model
             return new Trigger()
             {
                 Name = Name,
-                PersistantType = PersistantType,
+                PersistentType = PersistentType,
                 House = House,
                 EventControl = EventControl,
                 Event1 = Event1.Clone(),

--- a/CnCTDRAMapEditor/Model/TypeItem.cs
+++ b/CnCTDRAMapEditor/Model/TypeItem.cs
@@ -12,9 +12,11 @@
 // distributed with this program. You should have received a copy of the 
 // GNU General Public License along with permitted additional restrictions 
 // with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+using System;
+
 namespace MobiusEditor.Model
 {
-    public class TypeItem<T>
+    public class TypeItem<T>: System.IEquatable<TypeItem<T>>, IComparable<TypeItem<T>>
     {
         public string Name { get; private set; }
 
@@ -24,6 +26,20 @@ namespace MobiusEditor.Model
         {
             Name = name;
             Type = type;
+        }
+
+        public bool Equals(TypeItem<T> other)
+        {
+            return other != null
+                && ((this.Type == null && other.Type == null) || this.Type.Equals(other.Type))
+                && String.Equals(this.Name, other.Name, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public int CompareTo(TypeItem<T> other)
+        {
+            if (this.Equals(other))
+                return 0;
+            return String.Compare(this.Name ?? String.Empty, other.Name ?? String.Empty);
         }
     }
 }

--- a/CnCTDRAMapEditor/Model/UnitType.cs
+++ b/CnCTDRAMapEditor/Model/UnitType.cs
@@ -114,6 +114,7 @@ namespace MobiusEditor.Model
 
         public void Init(GameType gameType, TheaterType theater, HouseType house, DirectionType direction)
         {
+            var oldImage = Thumbnail;
             if (Globals.TheTilesetManager.GetTileData(theater.Tilesets, Name, 0, out Tile tile))
             {
                 RenderSize = new Size(tile.Image.Width / Globals.TileScale, tile.Image.Height / Globals.TileScale);
@@ -132,6 +133,11 @@ namespace MobiusEditor.Model
                 MapRenderer.Render(gameType, theater, new Point(1, 1), Globals.TileSize, mockUnit).Item2(g);
             }
             Thumbnail = unitThumbnail;
+            if (oldImage != null)
+            {
+                try { oldImage.Dispose(); }
+                catch { /* ignore */ }
+            }
         }
     }
 }

--- a/CnCTDRAMapEditor/Properties/AssemblyInfo.cs
+++ b/CnCTDRAMapEditor/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("C&C Tiberian Dawn and Red Alert Map Editor")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Rampastring")]
+[assembly: AssemblyCompany("Nyerguds")]
 [assembly: AssemblyProduct("CnC TDRA Map Editor")]
 [assembly: AssemblyCopyright("Command & Conquer and the original map editor © 2020 Electronic Arts Inc. All rights reserved.")]
 [assembly: AssemblyTrademark("")]

--- a/CnCTDRAMapEditor/Properties/Settings.Designer.cs
+++ b/CnCTDRAMapEditor/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MobiusEditor.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.9.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -29,18 +29,6 @@ namespace MobiusEditor.Properties {
         public int Quality {
             get {
                 return ((int)(this["Quality"]));
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
-        public bool ShowInviteWarning {
-            get {
-                return ((bool)(this["ShowInviteWarning"]));
-            }
-            set {
-                this["ShowInviteWarning"] = value;
             }
         }
         
@@ -209,6 +197,18 @@ namespace MobiusEditor.Properties {
             }
             set {
                 this["UnitToolDialogDefaultPosition"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowInviteWarning {
+            get {
+                return ((bool)(this["ShowInviteWarning"]));
+            }
+            set {
+                this["ShowInviteWarning"] = value;
             }
         }
     }

--- a/CnCTDRAMapEditor/RedAlert/SmudgeTypes.cs
+++ b/CnCTDRAMapEditor/RedAlert/SmudgeTypes.cs
@@ -22,21 +22,26 @@ namespace MobiusEditor.RedAlert
 {
     public static class SmudgeTypes
     {
-        public static readonly SmudgeType Crater1 = new SmudgeType(0, "cr1");
-        public static readonly SmudgeType Crater2 = new SmudgeType(1, "cr2");
-        public static readonly SmudgeType Crater3 = new SmudgeType(2, "cr3");
-        public static readonly SmudgeType Crater4 = new SmudgeType(3, "cr4");
-        public static readonly SmudgeType Crater5 = new SmudgeType(4, "cr5");
-        public static readonly SmudgeType Crater6 = new SmudgeType(5, "cr6");
+        public static readonly SmudgeType Crater1 = new SmudgeType(0, "cr1", 5);
+        public static readonly SmudgeType Crater2 = new SmudgeType(1, "cr2", 5);
+        public static readonly SmudgeType Crater3 = new SmudgeType(2, "cr3", 5);
+        public static readonly SmudgeType Crater4 = new SmudgeType(3, "cr4", 5);
+        public static readonly SmudgeType Crater5 = new SmudgeType(4, "cr5", 5);
+        public static readonly SmudgeType Crater6 = new SmudgeType(5, "cr6", 5);
         public static readonly SmudgeType Scorch1 = new SmudgeType(6, "sc1");
         public static readonly SmudgeType Scorch2 = new SmudgeType(7, "sc2");
         public static readonly SmudgeType Scorch3 = new SmudgeType(8, "sc3");
         public static readonly SmudgeType Scorch4 = new SmudgeType(9, "sc4");
         public static readonly SmudgeType Scorch5 = new SmudgeType(10, "sc5");
         public static readonly SmudgeType Scorch6 = new SmudgeType(11, "sc6");
-        public static readonly SmudgeType Bib1 = new SmudgeType(12, "bib1", new Size(4, 2), SmudgeTypeFlag.Bib1);
-        public static readonly SmudgeType Bib2 = new SmudgeType(13, "bib2", new Size(3, 2), SmudgeTypeFlag.Bib2);
-        public static readonly SmudgeType Bib3 = new SmudgeType(14, "bib3", new Size(2, 2), SmudgeTypeFlag.Bib3);
+        // placeable versions of the bibs. Experimental for now - UI doesn't seem able to handle their full size like the game does.
+        public static readonly SmudgeType Bib1Pl = new SmudgeType(12, "bib1", new Size(4, 2));
+        public static readonly SmudgeType Bib2Pl = new SmudgeType(13, "bib2", new Size(3, 2));
+        public static readonly SmudgeType Bib3Pl = new SmudgeType(14, "bib3", new Size(2, 2));
+        // The bibs to use under buildings. Kept separately to avoid conflict.
+        public static readonly SmudgeType Bib1 = new SmudgeType(15, "bib1", new Size(4, 2), SmudgeTypeFlag.Bib1);
+        public static readonly SmudgeType Bib2 = new SmudgeType(16, "bib2", new Size(3, 2), SmudgeTypeFlag.Bib2);
+        public static readonly SmudgeType Bib3 = new SmudgeType(17, "bib3", new Size(2, 2), SmudgeTypeFlag.Bib3);
 
         private static SmudgeType[] Types;
 

--- a/CnCTDRAMapEditor/Render/MapRenderer.cs
+++ b/CnCTDRAMapEditor/Render/MapRenderer.cs
@@ -386,63 +386,58 @@ namespace MobiusEditor.Render
                 Alignment = StringAlignment.Center,
                 LineAlignment = StringAlignment.Center
             };
-            var fakeBackgroundBrush = new SolidBrush(Color.FromArgb(building.Tint.A / 2, Color.Black));
-            var fakeTextBrush = new SolidBrush(Color.FromArgb(building.Tint.A, Color.White));
-            var baseBackgroundBrush = new SolidBrush(Color.FromArgb(building.Tint.A / 2, Color.Black));
-            var baseTextBrush = new SolidBrush(Color.FromArgb(building.Tint.A, Color.Red));
-
-            var icon = 0;
-            if (building.Type.HasTurret)
-            {
-                icon = BodyShape[Facing32[building.Direction.ID]];
-                if (building.Strength < 128)
+                var icon = 0;
+                if (building.Type.HasTurret)
                 {
-                    switch (gameType)
+                    icon = BodyShape[Facing32[building.Direction.ID]];
+                    if (building.Strength < 128)
                     {
-                        case GameType.TiberianDawn:
-                            icon += 64;
-                            break;
-                        case GameType.RedAlert:
-                            icon += building.Type.Equals("sam") ? 35 : 64;
-                            break;
+                        switch (gameType)
+                        {
+                            case GameType.TiberianDawn:
+                                icon += 64;
+                                break;
+                            case GameType.RedAlert:
+                                icon += building.Type.Equals("sam") ? 35 : 64;
+                                break;
+                        }
                     }
                 }
-            }
-            else
-            {
-                if (building.Strength <= 1)
+                else
                 {
-                    icon = -1;
+                    if (building.Strength <= 1)
+                    {
+                        icon = -1;
+                    }
+                    else if (building.Strength < 128)
+                    {
+                        icon = -2;
+                        if (building.Type.Equals("weap") || building.Type.Equals("weaf"))
+                        {
+                            icon = 1;
+                        }
+                        else if ((gameType == GameType.TiberianDawn) && building.Type.Equals("proc"))
+                        {
+                            icon = 30;
+                        }
+                        else if (building.Type.Equals("eye"))
+                        {
+                            icon = 16;
+                        }
+                        else if (building.Type.Equals("silo"))
+                        {
+                            icon = 5;
+                        }
+                        else if (building.Type.Equals("fix"))
+                        {
+                            icon = 7;
+                        }
+                        else if (building.Type.Equals("v19"))
+                        {
+                            icon = 14;
+                        }
+                    }
                 }
-                else if (building.Strength < 128)
-                {
-                    icon = -2;
-                    if (building.Type.Equals("weap") || building.Type.Equals("weaf"))
-                    {
-                        icon = 1;
-                    }
-                    else if ((gameType == GameType.TiberianDawn) && building.Type.Equals("proc"))
-                    {
-                        icon = 30;
-                    }
-                    else if (building.Type.Equals("eye"))
-                    {
-                        icon = 16;
-                    }
-                    else if (building.Type.Equals("silo"))
-                    {
-                        icon = 5;
-                    }
-                    else if (building.Type.Equals("fix"))
-                    {
-                        icon = 7;
-                    }
-                    else if (building.Type.Equals("v19"))
-                    {
-                        icon = 14;
-                    }
-                }
-            }
 
             if (Globals.TheTilesetManager.GetTeamColorTileData(theater.Tilesets, building.Type.Tilename, icon, Globals.TheTeamColorManager[building.House.BuildingTeamColor], out Tile tile))
             {
@@ -513,8 +508,12 @@ namespace MobiusEditor.Render
                         var text = Globals.TheGameTextManager["TEXT_UI_FAKE"];
                         var textSize = g.MeasureString(text, SystemFonts.CaptionFont) + new SizeF(6.0f, 6.0f);
                         var textBounds = new RectangleF(buildingBounds.Location, textSize);
-                        g.FillRectangle(fakeBackgroundBrush, textBounds);
-                        g.DrawString(text, SystemFonts.CaptionFont, fakeTextBrush, textBounds, stringFormat);
+                        using (var fakeBackgroundBrush = new SolidBrush(Color.FromArgb(building.Tint.A / 2, Color.Black)))
+                        using (var fakeTextBrush = new SolidBrush(Color.FromArgb(building.Tint.A, Color.White)))
+                        {
+                            g.FillRectangle(fakeBackgroundBrush, textBounds);
+                            g.DrawString(text, SystemFonts.CaptionFont, fakeTextBrush, textBounds, stringFormat);
+                        }
                     }
 
                     if (building.BasePriority >= 0)
@@ -525,8 +524,12 @@ namespace MobiusEditor.Render
                             new Size((int)((buildingBounds.Width - textSize.Width) / 2.0f), (int)(buildingBounds.Height - textSize.Height)),
                             textSize
                         );
-                        g.FillRectangle(baseBackgroundBrush, textBounds);
-                        g.DrawString(text, SystemFonts.CaptionFont, baseTextBrush, textBounds, stringFormat);
+                        using (var baseBackgroundBrush = new SolidBrush(Color.FromArgb(building.Tint.A / 2, Color.Black)))
+                        using (var baseTextBrush = new SolidBrush(Color.FromArgb(building.Tint.A, Color.Red)))
+                        {
+                            g.FillRectangle(baseBackgroundBrush, textBounds);
+                            g.DrawString(text, SystemFonts.CaptionFont, baseTextBrush, textBounds, stringFormat);
+                        }
                     }
                 }
 
@@ -536,7 +539,7 @@ namespace MobiusEditor.Render
             {
                 Debug.Print(string.Format("Building {0} (0) not found", building.Type.Name));
                 return (Rectangle.Empty, (g) => { });
-            }
+            }            
         }
 
         public static (Rectangle, Action<Graphics>) Render(TheaterType theater, Point topLeft, Size tileSize, Infantry infantry, InfantryStoppingType infantryStoppingType)
@@ -801,13 +804,14 @@ namespace MobiusEditor.Render
                         }
                         else if (gameType == GameType.TiberianDawn)
                         {
-                            if ((unit.Type == TiberianDawn.UnitTypes.Jeep) ||
-                                (unit.Type == TiberianDawn.UnitTypes.Buggy))
+                            if (unit.Type == TiberianDawn.UnitTypes.Jeep ||
+                                unit.Type == TiberianDawn.UnitTypes.Buggy ||
+                                unit.Type == TiberianDawn.UnitTypes.MHQ)
                             {
                                 turretAdjust.Y = -4;
                             }
-                            else if ((unit.Type == TiberianDawn.UnitTypes.SAM) ||
-                                     (unit.Type == TiberianDawn.UnitTypes.MLRS))
+                            else if (unit.Type == TiberianDawn.UnitTypes.SSM ||
+                                     unit.Type == TiberianDawn.UnitTypes.MLRS)
                             {
                                 turretAdjust = TurretAdjust[Facing32[unit.Direction.ID]];
                             }

--- a/CnCTDRAMapEditor/TiberianDawn/GamePlugin.cs
+++ b/CnCTDRAMapEditor/TiberianDawn/GamePlugin.cs
@@ -48,13 +48,13 @@ namespace MobiusEditor.TiberianDawn
 
         static GamePlugin()
         {
-            technoTypes = InfantryTypes.GetTypes().Cast<ITechnoType>().Concat(UnitTypes.GetTypes().Cast<ITechnoType>());
+            technoTypes = InfantryTypes.GetTypes().Cast<ITechnoType>().Concat(UnitTypes.GetTypes(false).Cast<ITechnoType>());
         }
 
         public GamePlugin(bool mapImage)
         {
-            var playerWaypoints = Enumerable.Range(0, 8).Select(i => new Waypoint(string.Format("P{0}", i), WaypointFlag.PlayerStart));
-            var generalWaypoints = Enumerable.Range(8, 17).Select(i => new Waypoint(i.ToString()));
+            var playerWaypoints = Enumerable.Range(0, 6).Select(i => new Waypoint(string.Format("P{0}", i), WaypointFlag.PlayerStart));
+            var generalWaypoints = Enumerable.Range(6, 19).Select(i => new Waypoint(i.ToString()));
             var specialWaypoints = new Waypoint[] { new Waypoint("Flare"), new Waypoint("Home"), new Waypoint("Reinf.") };
             var waypoints = playerWaypoints.Concat(generalWaypoints).Concat(specialWaypoints);
 
@@ -81,8 +81,8 @@ namespace MobiusEditor.TiberianDawn
             Map = new Map(basicSection, null, Constants.MaxSize, typeof(House),
                 houseTypes, TheaterTypes.GetTypes(), TemplateTypes.GetTypes(), TerrainTypes.GetTypes(),
                 OverlayTypes.GetTypes(), SmudgeTypes.GetTypes(), EventTypes.GetTypes(), ActionTypes.GetTypes(),
-                MissionTypes.GetTypes(), DirectionTypes.GetTypes(), InfantryTypes.GetTypes(), UnitTypes.GetTypes(),
-                BuildingTypes.GetTypes(), TeamMissionTypes.GetTypes(), waypoints, movieTypes)
+                MissionTypes.GetTypes(), DirectionTypes.GetTypes(), InfantryTypes.GetTypes(), UnitTypes.GetTypes(true),
+                BuildingTypes.GetTypes(), TeamMissionTypes.GetTypes(), technoTypes, waypoints, movieTypes)
             {
                 TiberiumOrGoldValue = 25
             };
@@ -199,6 +199,8 @@ namespace MobiusEditor.TiberianDawn
             }
 
             var teamTypesSection = ini.Sections.Extract("TeamTypes");
+            // Make case insensitive dictionary of teamtype missions.
+            Dictionary<string, string> teamMissionTypes = Enumerable.ToDictionary(TeamMissionTypes.GetTypes(), t => t, StringComparer.OrdinalIgnoreCase);
             if (teamTypesSection != null)
             {
                 foreach (var (Key, Value) in teamTypesSection)
@@ -226,7 +228,9 @@ namespace MobiusEditor.TiberianDawn
                             if (classTokens.Length == 2)
                             {
                                 var type = technoTypes.Where(t => t.Equals(classTokens[0])).FirstOrDefault();
-                                var count = byte.Parse(classTokens[1]);
+                                byte count;
+                                if (!byte.TryParse(classTokens[1], out count))
+                                    count = 1;
                                 if (type != null)
                                 {
                                     teamType.Classes.Add(new TeamTypeClass { Type = type, Count = count });
@@ -248,7 +252,19 @@ namespace MobiusEditor.TiberianDawn
                             var missionTokens = tokens[0].Split(':'); tokens.RemoveAt(0);
                             if (missionTokens.Length == 2)
                             {
-                                teamType.Missions.Add(new TeamTypeMission { Mission = missionTokens[0], Argument = int.Parse(missionTokens[1]) });
+                                string mission;
+                                // fix mission case sensitivity issues.
+                                teamMissionTypes.TryGetValue(missionTokens[0], out mission);
+                                byte count;
+                                byte.TryParse(missionTokens[1], out count);
+                                if (mission != null)
+                                {
+                                    teamType.Missions.Add(new TeamTypeMission { Mission = mission, Argument = count });
+                                }
+                                else
+                                {
+                                    errors.Add(string.Format("Team '{0}' references unknown class '{1}'", Key, missionTokens[0]));
+                                }
                             }
                             else
                             {
@@ -286,12 +302,14 @@ namespace MobiusEditor.TiberianDawn
                         trigger.Event1.Data = long.Parse(tokens[2]);
                         trigger.Action1.ActionType = tokens[1];
                         trigger.House = Map.HouseTypes.Where(t => t.Equals(tokens[3])).FirstOrDefault()?.Name ?? "None";
+                        if (String.IsNullOrEmpty(tokens[4]))
+                            tokens[4] = TeamType.None;
                         trigger.Action1.Team = tokens[4];
-                        trigger.PersistantType = TriggerPersistantType.Volatile;
+                        trigger.PersistentType = TriggerPersistentType.Volatile;
 
                         if (tokens.Length >= 6)
                         {
-                            trigger.PersistantType = (TriggerPersistantType)int.Parse(tokens[5]);
+                            trigger.PersistentType = (TriggerPersistentType)int.Parse(tokens[5]);
                         }
 
                         Map.Triggers.Add(trigger);
@@ -388,22 +406,17 @@ namespace MobiusEditor.TiberianDawn
                     var tokens = Value.Split(',');
                     if (tokens.Length == 3)
                     {
-                        var smudgeType = Map.SmudgeTypes.Where(t => t.Equals(tokens[0])).FirstOrDefault();
+                        var smudgeType = Map.SmudgeTypes.Where(t => t.Equals(tokens[0]) && (t.Flag & SmudgeTypeFlag.Bib) == 0).FirstOrDefault();
                         if (smudgeType != null)
                         {
-                            if (((smudgeType.Flag & SmudgeTypeFlag.Bib) == SmudgeTypeFlag.None))
+                            int icon = 0;
+                            if (smudgeType.Icons > 1 && int.TryParse(tokens[2], out icon))
+                                icon = Math.Max(0, Math.Min(smudgeType.Icons - 1, icon));
+                            Map.Smudge[cell] = new Smudge
                             {
-                                Map.Smudge[cell] = new Smudge
-                                {
-                                    Type = smudgeType,
-                                    Icon = 0,
-                                    Data = int.Parse(tokens[2])
-                                };
-                            }
-                            else
-                            {
-                                errors.Add(string.Format("Smudge '{0}' is a bib, skipped", tokens[0]));
-                            }
+                                Type = smudgeType,
+                                Icon = icon
+                            };
                         }
                         else
                         {
@@ -873,17 +886,26 @@ namespace MobiusEditor.TiberianDawn
                         var jsonPath = Path.ChangeExtension(path, ".json");
 
                         var ini = new INI();
+                        SaveINI(ini, fileType);
                         using (var iniWriter = new StreamWriter(iniPath))
+                        {
+                            iniWriter.Write(ini.ToString());
+                        }
+
                         using (var binStream = new FileStream(binPath, FileMode.Create))
                         using (var binWriter = new BinaryWriter(binStream))
+                        {
+                            SaveBinary(binWriter);
+                        }
+
                         using (var tgaStream = new FileStream(tgaPath, FileMode.Create))
+                        {
+                            SaveMapPreview(tgaStream);
+                        }
+
                         using (var jsonStream = new FileStream(jsonPath, FileMode.Create))
                         using (var jsonWriter = new JsonTextWriter(new StreamWriter(jsonStream)))
                         {
-                            SaveINI(ini, fileType);
-                            iniWriter.Write(ini.ToString());
-                            SaveBinary(binWriter);
-                            SaveMapPreview(tgaStream);
                             SaveJSON(jsonWriter);
                         }
                     }
@@ -891,6 +913,8 @@ namespace MobiusEditor.TiberianDawn
                 case FileType.MEG:
                 case FileType.PGM:
                     {
+                        var ini = new INI();
+                        SaveINI(ini, fileType);
                         using (var iniStream = new MemoryStream())
                         using (var binStream = new MemoryStream())
                         using (var tgaStream = new MemoryStream())
@@ -899,8 +923,6 @@ namespace MobiusEditor.TiberianDawn
                         using (var jsonWriter = new JsonTextWriter(new StreamWriter(jsonStream)))
                         using (var megafileBuilder = new MegafileBuilder(@"", path))
                         {
-                            var ini = new INI();
-                            SaveINI(ini, fileType);
                             var iniWriter = new StreamWriter(iniStream);
                             iniWriter.Write(ini.ToString());
                             iniWriter.Flush();
@@ -1011,9 +1033,9 @@ namespace MobiusEditor.TiberianDawn
                     trigger.Event1.EventType,
                     trigger.Action1.ActionType,
                     trigger.Event1.Data.ToString(),
-                    trigger.House,
-                    trigger.Action1.Team,
-                    ((int)trigger.PersistantType).ToString()
+                    String.IsNullOrEmpty(trigger.House) ? House.None : trigger.House,
+                    String.IsNullOrEmpty(trigger.Action1.Team) ? TeamType.None : trigger.Action1.Team,
+                    ((int)trigger.PersistentType).ToString()
                 };
 
                 triggersSection[trigger.Name] = string.Join(",", tokens);
@@ -1066,7 +1088,7 @@ namespace MobiusEditor.TiberianDawn
                         infantry.Strength,
                         cell,
                         i,
-                        infantry.Mission,
+                        String.IsNullOrEmpty(infantry.Mission) ? "Guard" : infantry.Mission,
                         infantry.Direction.ID,
                         infantry.Trigger
                     );
@@ -1105,11 +1127,11 @@ namespace MobiusEditor.TiberianDawn
                     unit.Strength,
                     cell,
                     unit.Direction.ID,
-                    unit.Mission,
+                    String.IsNullOrEmpty(unit.Mission) ? "Guard" : unit.Mission,
                     unit.Trigger
                 );
             }
-
+            // Game does not actually support reading this.
             var aircraftSection = ini.Sections.Add("Aircraft");
             var aircraftIndex = 0;
             foreach (var (location, aircraft) in Map.Technos.OfType<Unit>().Where(u => u.Occupier.Type.IsAircraft))
@@ -1124,7 +1146,7 @@ namespace MobiusEditor.TiberianDawn
                     aircraft.Strength,
                     cell,
                     aircraft.Direction.ID,
-                    aircraft.Mission
+                    String.IsNullOrEmpty(aircraft.Mission) ? "Guard" : aircraft.Mission
                 );
             }
 
@@ -1139,22 +1161,27 @@ namespace MobiusEditor.TiberianDawn
             }
 
             var overlaySection = ini.Sections.Add("Overlay");
+            Regex tiberium = new Regex("TI([0-9]|(1[0-2]))", RegexOptions.IgnoreCase);
+            Random rd = new Random();
             foreach (var (cell, overlay) in Map.Overlay)
             {
-                overlaySection[cell.ToString()] = overlay.Type.Name;
+                String overlayName = overlay.Type.Name;
+                if (tiberium.IsMatch(overlayName))
+                    overlayName = "TI" + rd.Next(1, 12);
+                overlaySection[cell.ToString()] = overlayName.ToUpperInvariant();
             }
 
             var smudgeSection = ini.Sections.Add("Smudge");
             foreach (var (cell, smudge) in Map.Smudge.Where(item => (item.Value.Type.Flag & SmudgeTypeFlag.Bib) == SmudgeTypeFlag.None))
             {
-                smudgeSection[cell.ToString()] = string.Format("{0},{1},{2}", smudge.Type.Name, cell, smudge.Data);
+                smudgeSection[cell.ToString()] = string.Format("{0},{1},{2}", smudge.Type.Name, cell, smudge.Icon);
             }
 
             var terrainSection = ini.Sections.Add("Terrain");
             foreach (var (location, terrain) in Map.Technos.OfType<Terrain>())
             {
                 Map.Metrics.GetCell(location, out int cell);
-                terrainSection[cell.ToString()] = string.Format("{0},None", terrain.Type.Name);
+                terrainSection[cell.ToString()] = string.Format("{0},{1}", terrain.Type.Name, terrain.Trigger);
             }
         }
 
@@ -1173,7 +1200,7 @@ namespace MobiusEditor.TiberianDawn
                     else
                     {
                         writer.Write(byte.MaxValue);
-                        writer.Write(byte.MaxValue);
+                        writer.Write(byte.MinValue);
                     }
                 }
             }

--- a/CnCTDRAMapEditor/TiberianDawn/House.cs
+++ b/CnCTDRAMapEditor/TiberianDawn/House.cs
@@ -16,6 +16,8 @@ namespace MobiusEditor.TiberianDawn
 {
     public class House : Model.House
     {
+        public static readonly string None = "None";
+
         public House(Model.HouseType type)
             : base(type)
         {

--- a/CnCTDRAMapEditor/TiberianDawn/MissionTypes.cs
+++ b/CnCTDRAMapEditor/TiberianDawn/MissionTypes.cs
@@ -20,28 +20,29 @@ namespace MobiusEditor.TiberianDawn
     {
         private static readonly string[] Types = new string[]
         {
+            // Nyerguds upgrade: Removed irrelevant types for preplaced units.
             "Sleep",
-            "Attack",
-            "Move",
-            "Retreat",
+            //"Attack",
+            //"Move",
+            //"Retreat",
             "Guard",
             "Sticky",
-            "Enter",
-            "Capture",
+            //"Enter",
+            //"Capture",
             "Harvest",
             "Area Guard",
             "Return",
             "Stop",
-            "Ambush",
+            //"Ambush",
             "Hunt",
-            "Timed Hunt",
-            "Unload",
-            "Sabotage",
-            "Construction",
-            "Selling",
-            "Repair",
-            "Rescue",
-            "Missile"
+            //"Timed Hunt",
+            //"Unload",
+            //"Sabotage",
+            //"Construction",
+            //"Selling",
+            //"Repair",
+            //"Rescue",
+            //"Missile"
         };
 
         public static IEnumerable<string> GetTypes()

--- a/CnCTDRAMapEditor/TiberianDawn/OverlayTypes.cs
+++ b/CnCTDRAMapEditor/TiberianDawn/OverlayTypes.cs
@@ -48,6 +48,9 @@ namespace MobiusEditor.TiberianDawn
         public static readonly OverlayType FlagSpot = new OverlayType(27, "fpls", OverlayTypeFlag.Flag);
         public static readonly OverlayType WoodCrate = new OverlayType(28, "wcrate", OverlayTypeFlag.Crate);
         public static readonly OverlayType SteelCrate = new OverlayType(29, "scrate", OverlayTypeFlag.Crate);
+        // Nyerguds upgrade: Added missing types CONC and ROAD.
+        public static readonly OverlayType Concrete = new OverlayType(30, "conc", OverlayTypeFlag.Decoration);
+        public static readonly OverlayType Road = new OverlayType(29, "road", OverlayTypeFlag.Decoration);
 
         private static OverlayType[] Types;
 

--- a/CnCTDRAMapEditor/TiberianDawn/SmudgeTypes.cs
+++ b/CnCTDRAMapEditor/TiberianDawn/SmudgeTypes.cs
@@ -22,21 +22,26 @@ namespace MobiusEditor.TiberianDawn
 {
     public static class SmudgeTypes
     {
-        public static readonly SmudgeType Crater1 = new SmudgeType(0, "cr1");
-        public static readonly SmudgeType Crater2 = new SmudgeType(1, "cr2");
-        public static readonly SmudgeType Crater3 = new SmudgeType(2, "cr3");
-        public static readonly SmudgeType Crater4 = new SmudgeType(3, "cr4");
-        public static readonly SmudgeType Crater5 = new SmudgeType(4, "cr5");
-        public static readonly SmudgeType Crater6 = new SmudgeType(5, "cr6");
+        public static readonly SmudgeType Crater1 = new SmudgeType(0, "cr1", 5);
+        public static readonly SmudgeType Crater4 = new SmudgeType(3, "cr4", 5);
+        public static readonly SmudgeType Crater5 = new SmudgeType(4, "cr5", 5);
+        public static readonly SmudgeType Crater2 = new SmudgeType(1, "cr2", 5);
+        public static readonly SmudgeType Crater6 = new SmudgeType(5, "cr6", 5);
+        public static readonly SmudgeType Crater3 = new SmudgeType(2, "cr3", 5);
         public static readonly SmudgeType Scorch1 = new SmudgeType(6, "sc1");
         public static readonly SmudgeType Scorch2 = new SmudgeType(7, "sc2");
         public static readonly SmudgeType Scorch3 = new SmudgeType(8, "sc3");
         public static readonly SmudgeType Scorch4 = new SmudgeType(9, "sc4");
         public static readonly SmudgeType Scorch5 = new SmudgeType(10, "sc5");
         public static readonly SmudgeType Scorch6 = new SmudgeType(11, "sc6");
-        public static readonly SmudgeType Bib1 = new SmudgeType(12, "bib1", new Size(4, 2), SmudgeTypeFlag.Bib1);
-        public static readonly SmudgeType Bib2 = new SmudgeType(13, "bib2", new Size(3, 2), SmudgeTypeFlag.Bib2);
-        public static readonly SmudgeType Bib3 = new SmudgeType(14, "bib3", new Size(2, 2), SmudgeTypeFlag.Bib3);
+        // placeable versions of the bibs. Experimental for now - UI doesn't seem able to handle their full size like the game does.
+        public static readonly SmudgeType Bib1Pl = new SmudgeType(12, "bib1", new Size(4, 2));
+        public static readonly SmudgeType Bib2Pl = new SmudgeType(13, "bib2", new Size(3, 2));
+        public static readonly SmudgeType Bib3Pl = new SmudgeType(14, "bib3", new Size(2, 2));
+        // The bibs to use under buildings. Kept separately to avoid conflict.
+        public static readonly SmudgeType Bib1 = new SmudgeType(15, "bib1", new Size(4, 2), SmudgeTypeFlag.Bib1);
+        public static readonly SmudgeType Bib2 = new SmudgeType(16, "bib2", new Size(3, 2), SmudgeTypeFlag.Bib2);
+        public static readonly SmudgeType Bib3 = new SmudgeType(17, "bib3", new Size(2, 2), SmudgeTypeFlag.Bib3);
 
         private static SmudgeType[] Types;
 

--- a/CnCTDRAMapEditor/TiberianDawn/UnitTypes.cs
+++ b/CnCTDRAMapEditor/TiberianDawn/UnitTypes.cs
@@ -12,6 +12,7 @@
 // distributed with this program. You should have received a copy of the 
 // GNU General Public License along with permitted additional restrictions 
 // with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+using System;
 using MobiusEditor.Model;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,9 +34,9 @@ namespace MobiusEditor.TiberianDawn
         public static readonly UnitType Buggy = new UnitType(9, "bggy", "TEXT_UNIT_TITLE_NOD_NOD_BUGGY", "Badguy", true);
         public static readonly UnitType Harvester = new UnitType(10, "harv", "TEXT_UNIT_TITLE_GDI_HARVESTER", "Goodguy");
         public static readonly UnitType Arty = new UnitType(11, "arty", "TEXT_UNIT_TITLE_NOD_ARTILLERY", "Badguy");
-        public static readonly UnitType SAM = new UnitType(12, "mlrs", "TEXT_UNIT_TITLE_GDI_MLRS", "Goodguy", true);
+        public static readonly UnitType SSM = new UnitType(12, "mlrs", "TEXT_UNIT_TITLE_GDI_MLRS", "Badguy", true);
         public static readonly UnitType Hover = new UnitType(13, "lst", "TEXT_UNIT_TITLE_LST", "Goodguy");
-        public static readonly UnitType MHQ = new UnitType(14, "mhq", "TEXT_UNIT_TITLE_MHQ", "Goodguy");
+        public static readonly UnitType MHQ = new UnitType(14, "mhq", "TEXT_UNIT_TITLE_MHQ", "Goodguy", true);
         public static readonly UnitType GunBoat = new UnitType(15, "boat", "TEXT_UNIT_TITLE_WAKE", "Goodguy", true);
         public static readonly UnitType MCV = new UnitType(16, "mcv", "TEXT_UNIT_TITLE_GDI_MCV", "Goodguy");
         public static readonly UnitType Bike = new UnitType(17, "bike", "TEXT_UNIT_TITLE_NOD_RECON_BIKE", "Badguy");
@@ -60,8 +61,11 @@ namespace MobiusEditor.TiberianDawn
                  select field.GetValue(null) as UnitType).ToArray();
         }
 
-        public static IEnumerable<UnitType> GetTypes()
+        public static IEnumerable<UnitType> GetTypes(Boolean placeable)
         {
+            // only return placeable units; you can't place down aircraft in C&C
+            if (placeable)
+                return Types.Where(t => (t.IsUnit));
             return Types;
         }
     }

--- a/CnCTDRAMapEditor/Tools/Dialogs/BuildingToolDialog.cs
+++ b/CnCTDRAMapEditor/Tools/Dialogs/BuildingToolDialog.cs
@@ -19,8 +19,7 @@ namespace MobiusEditor.Tools.Dialogs
         {
             ObjectTypeListBox.Types = plugin.Map.BuildingTypes
                 .Where(t => (t.Theaters == null) || t.Theaters.Contains(plugin.Map.Theater))
-                .OrderBy(t => t.IsFake)
-                .ThenBy(t => t.Name);
+                .OrderBy(t => t.ID);
             Tool = new BuildingTool(mapPanel, activeLayers, toolStatusLabel, ObjectTypeListBox,
                 ObjectTypeMapPanel, ObjectProperties, plugin, undoRedoList);
         }

--- a/CnCTDRAMapEditor/Tools/Dialogs/InfantryToolDialog.cs
+++ b/CnCTDRAMapEditor/Tools/Dialogs/InfantryToolDialog.cs
@@ -17,7 +17,7 @@ namespace MobiusEditor.Tools.Dialogs
 
         public override void Initialize(MapPanel mapPanel, MapLayerFlag activeLayers, ToolStripStatusLabel toolStatusLabel, ToolTip mouseToolTip, IGamePlugin plugin, UndoRedoList<UndoRedoEventArgs> undoRedoList)
         {
-            ObjectTypeListBox.Types = plugin.Map.InfantryTypes.OrderBy(t => t.Name);
+            ObjectTypeListBox.Types = plugin.Map.InfantryTypes.OrderBy(t => t.ID);
             Tool = new InfantryTool(mapPanel, activeLayers, toolStatusLabel, ObjectTypeListBox,
                 ObjectTypeMapPanel, ObjectProperties, plugin, undoRedoList);
         }

--- a/CnCTDRAMapEditor/Tools/Dialogs/ResourcesToolDialog.Designer.cs
+++ b/CnCTDRAMapEditor/Tools/Dialogs/ResourcesToolDialog.Designer.cs
@@ -46,7 +46,7 @@ namespace MobiusEditor.Tools.Dialogs
             this.label10 = new System.Windows.Forms.Label();
             this.totalResourcesLbl = new System.Windows.Forms.Label();
             this.gemsCheckBox = new System.Windows.Forms.CheckBox();
-            this.resourceBrushSizeNud = new System.Windows.Forms.NumericUpDown();
+            this.resourceBrushSizeNud = new MobiusEditor.Controls.EnhNumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
             this.tableLayoutPanel6.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.resourceBrushSizeNud)).BeginInit();
@@ -113,6 +113,7 @@ namespace MobiusEditor.Tools.Dialogs
             0,
             0,
             0});
+            this.resourceBrushSizeNud.MouseWheelIncrement = 2;
             this.resourceBrushSizeNud.Location = new System.Drawing.Point(97, 16);
             this.resourceBrushSizeNud.Maximum = new decimal(new int[] {
             9,
@@ -173,7 +174,7 @@ namespace MobiusEditor.Tools.Dialogs
         private System.Windows.Forms.Label label10;
         private System.Windows.Forms.Label totalResourcesLbl;
         private System.Windows.Forms.CheckBox gemsCheckBox;
-        private System.Windows.Forms.NumericUpDown resourceBrushSizeNud;
+        private MobiusEditor.Controls.EnhNumericUpDown resourceBrushSizeNud;
         private System.Windows.Forms.Label label1;
     }
 }

--- a/CnCTDRAMapEditor/Tools/Dialogs/SmudgeToolDialog.cs
+++ b/CnCTDRAMapEditor/Tools/Dialogs/SmudgeToolDialog.cs
@@ -18,7 +18,7 @@ namespace MobiusEditor.Tools.Dialogs
         public override void Initialize(MapPanel mapPanel, MapLayerFlag activeLayers, ToolStripStatusLabel toolStatusLabel,
             ToolTip mouseToolTip, IGamePlugin plugin, UndoRedoList<UndoRedoEventArgs> undoRedoList)
         {
-            GenericTypeListBox.Types = plugin.Map.SmudgeTypes.Where(t => (t.Flag & SmudgeTypeFlag.Bib) == SmudgeTypeFlag.None).OrderBy(t => t.Name);
+            GenericTypeListBox.Types = plugin.Map.SmudgeTypes.Where(t => (t.Flag & SmudgeTypeFlag.Bib) == SmudgeTypeFlag.None).OrderBy(t => t.ID);
             Tool = new SmudgeTool(mapPanel, activeLayers, toolStatusLabel, GenericTypeListBox, GenericTypeMapPanel, plugin, undoRedoList);
         }
     }

--- a/CnCTDRAMapEditor/Tools/Dialogs/TerrainToolDialog.cs
+++ b/CnCTDRAMapEditor/Tools/Dialogs/TerrainToolDialog.cs
@@ -44,7 +44,7 @@ namespace MobiusEditor.Tools.Dialogs
 
         public override void Initialize(MapPanel mapPanel, MapLayerFlag activeLayers, ToolStripStatusLabel toolStatusLabel, ToolTip mouseToolTip, IGamePlugin plugin, UndoRedoList<UndoRedoEventArgs> undoRedoList)
         {
-            TerrainTypeComboBox.Types = plugin.Map.TerrainTypes.Where(t => t.Theaters.Contains(plugin.Map.Theater)).OrderBy(t => t.Name);
+            TerrainTypeComboBox.Types = plugin.Map.TerrainTypes.Where(t => t.Theaters.Contains(plugin.Map.Theater)).OrderBy(t => t.ID);
             Tool = new TerrainTool(mapPanel, activeLayers, toolStatusLabel, TerrainTypeComboBox,
                 TerrainTypeMapPanel, TerrainProperties, plugin, undoRedoList);
         }

--- a/CnCTDRAMapEditor/Tools/Dialogs/UnitToolDialog.cs
+++ b/CnCTDRAMapEditor/Tools/Dialogs/UnitToolDialog.cs
@@ -17,7 +17,7 @@ namespace MobiusEditor.Tools.Dialogs
 
         public override void Initialize(MapPanel mapPanel, MapLayerFlag activeLayers, ToolStripStatusLabel toolStatusLabel, ToolTip mouseToolTip, IGamePlugin plugin, UndoRedoList<UndoRedoEventArgs> undoRedoList)
         {
-            ObjectTypeListBox.Types = plugin.Map.UnitTypes.Where(t => !t.IsFixedWing).OrderBy(t => t.Name);
+            ObjectTypeListBox.Types = plugin.Map.UnitTypes.Where(t => !t.IsFixedWing).OrderBy(t => t.ID);
             Tool = new UnitTool(mapPanel, activeLayers, toolStatusLabel, ObjectTypeListBox,
                 ObjectTypeMapPanel, ObjectProperties, plugin, undoRedoList);
         }

--- a/CnCTDRAMapEditor/Tools/Dialogs/WallsToolDialog.cs
+++ b/CnCTDRAMapEditor/Tools/Dialogs/WallsToolDialog.cs
@@ -17,7 +17,7 @@ namespace MobiusEditor.Tools.Dialogs
 
         public override void Initialize(MapPanel mapPanel, MapLayerFlag activeLayers, ToolStripStatusLabel toolStatusLabel, ToolTip mouseToolTip, IGamePlugin plugin, UndoRedoList<UndoRedoEventArgs> undoRedoList)
         {
-            GenericTypeListBox.Types = plugin.Map.OverlayTypes.Where(t => t.IsWall).OrderBy(t => t.Name);
+            GenericTypeListBox.Types = plugin.Map.OverlayTypes.Where(t => t.IsWall).OrderBy(t => t.ID);
             Tool = new WallsTool(mapPanel, activeLayers, toolStatusLabel,
                 GenericTypeListBox, GenericTypeMapPanel, plugin, undoRedoList);
         }

--- a/CnCTDRAMapEditor/Tools/InfantryTool.cs
+++ b/CnCTDRAMapEditor/Tools/InfantryTool.cs
@@ -412,6 +412,7 @@ namespace MobiusEditor.Tools
 
         private void RefreshMapPanel()
         {
+            var oldImage = infantryTypeMapPanel.MapImage;
             if (mockInfantry.Type != null)
             {
                 var infantryPreview = new Bitmap(Globals.TileWidth, Globals.TileHeight);
@@ -424,6 +425,11 @@ namespace MobiusEditor.Tools
             else
             {
                 infantryTypeMapPanel.MapImage = null;
+            }
+            if (oldImage != null)
+            {
+                try { oldImage.Dispose(); }
+                catch { /* ignore */ }
             }
         }
 
@@ -439,7 +445,7 @@ namespace MobiusEditor.Tools
             }
             else
             {
-                statusLbl.Text = "Shift to enter placement mode, Left-Click drag to move infantry, Double-Click update infantry properties, Right-Click to pick infantry";
+                statusLbl.Text = "Shift to enter placement mode, Left-Click drag to move infantry, Double-Click to update infantry properties, Right-Click to pick infantry";
             }
         }
 
@@ -490,11 +496,13 @@ namespace MobiusEditor.Tools
         {
             base.PostRenderMap(graphics);
 
-            var infantryPen = new Pen(Color.Green, 4.0f);
-            foreach (var (topLeft, _) in map.Technos.OfType<InfantryGroup>())
+            using (var infantryPen = new Pen(Color.Green, 4.0f))
             {
-                var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
-                graphics.DrawRectangle(infantryPen, bounds);
+                foreach (var (topLeft, _) in map.Technos.OfType<InfantryGroup>())
+                {
+                    var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
+                    graphics.DrawRectangle(infantryPen, bounds);
+                }
             }
         }
 

--- a/CnCTDRAMapEditor/Tools/OverlaysTool.cs
+++ b/CnCTDRAMapEditor/Tools/OverlaysTool.cs
@@ -241,7 +241,8 @@ namespace MobiusEditor.Tools
             if (map.Metrics.GetCell(location, out int cell))
             {
                 var overlay = map.Overlay[cell];
-                if ((overlay != null) && !overlay.Type.IsWall)
+                // Nyerguds fix: this should use the same filter as the list fill! Crashed on resources.
+                if ((overlay != null) && overlay.Type.IsPlaceable)
                 {
                     SelectedOverlayType = overlay.Type;
                 }
@@ -294,13 +295,14 @@ namespace MobiusEditor.Tools
         protected override void PostRenderMap(Graphics graphics)
         {
             base.PostRenderMap(graphics);
-
-            var overlayPen = new Pen(Color.Green, 4.0f);
-            foreach (var (cell, overlay) in previewMap.Overlay.Where(x => x.Value.Type.IsPlaceable))
+            using (var overlayPen = new Pen(Color.Green, 4.0f))
             {
-                previewMap.Metrics.GetLocation(cell, out Point topLeft);
-                var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
-                graphics.DrawRectangle(overlayPen, bounds);
+                foreach (var (cell, overlay) in previewMap.Overlay.Where(x => x.Value.Type.IsPlaceable))
+                {
+                    previewMap.Metrics.GetLocation(cell, out Point topLeft);
+                    var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
+                    graphics.DrawRectangle(overlayPen, bounds);
+                }
             }
         }
 

--- a/CnCTDRAMapEditor/Tools/ResourcesTool.cs
+++ b/CnCTDRAMapEditor/Tools/ResourcesTool.cs
@@ -312,14 +312,16 @@ namespace MobiusEditor.Tools
         {
             base.PostRenderMap(graphics);
 
-            var resourcePen = new Pen(Color.Green, 4.0f);
-            foreach (var (cell, overlay) in map.Overlay)
+            using (var resourcePen = new Pen(Color.Green, 4.0f))
             {
-                if (overlay.Type.IsResource)
+                foreach (var (cell, overlay) in map.Overlay)
                 {
-                    map.Metrics.GetLocation(cell, out Point topLeft);
-                    var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
-                    graphics.DrawRectangle(resourcePen, bounds);
+                    if (overlay.Type.IsResource)
+                    {
+                        map.Metrics.GetLocation(cell, out Point topLeft);
+                        var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
+                        graphics.DrawRectangle(resourcePen, bounds);
+                    }
                 }
             }
         }

--- a/CnCTDRAMapEditor/Tools/TerrainTool.cs
+++ b/CnCTDRAMapEditor/Tools/TerrainTool.cs
@@ -390,19 +390,19 @@ namespace MobiusEditor.Tools
         {
             base.PostRenderMap(graphics);
 
-            var terrainPen = new Pen(Color.Green, 4.0f);
-            var occupyPen = new Pen(Color.Red, 2.0f);
-            foreach (var (topLeft, terrain) in previewMap.Technos.OfType<Terrain>())
+            using (var terrainPen = new Pen(Color.Green, 4.0f))
+            using (var occupyPen = new Pen(Color.Red, 2.0f))
             {
-                var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), terrain.Type.RenderSize);
-                graphics.DrawRectangle(terrainPen, bounds);
-
-                for (var y = 0; y < terrain.Type.OccupyMask.GetLength(0); ++y)
+                foreach (var (topLeft, terrain) in previewMap.Technos.OfType<Terrain>())
                 {
-                    for (var x = 0; x < terrain.Type.OccupyMask.GetLength(1); ++x)
+                    var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), terrain.Type.RenderSize);
+                    graphics.DrawRectangle(terrainPen, bounds);
+                    for (var y = 0; y < terrain.Type.OccupyMask.GetLength(0); ++y)
                     {
-                        if (terrain.Type.OccupyMask[y, x])
+                        for (var x = 0; x < terrain.Type.OccupyMask.GetLength(1); ++x)
                         {
+                            if (!terrain.Type.OccupyMask[y, x])
+                                continue;
                             var occupyBounds = new Rectangle(
                                 new Point((topLeft.X + x) * Globals.TileWidth, (topLeft.Y + y) * Globals.TileHeight),
                                 Globals.TileSize

--- a/CnCTDRAMapEditor/Tools/UnitTool.cs
+++ b/CnCTDRAMapEditor/Tools/UnitTool.cs
@@ -322,6 +322,7 @@ namespace MobiusEditor.Tools
 
         private void RefreshMapPanel()
         {
+            var oldImage = unitTypeMapPanel.MapImage;
             if (mockUnit.Type != null)
             {
                 var unitPreview = new Bitmap(Globals.TileWidth * 3, Globals.TileHeight * 3);
@@ -334,6 +335,11 @@ namespace MobiusEditor.Tools
             else
             {
                 unitTypeMapPanel.MapImage = null;
+            }
+            if (oldImage != null)
+            {
+                try { oldImage.Dispose(); }
+                catch { /* ignore */ }
             }
         }
 
@@ -376,12 +382,13 @@ namespace MobiusEditor.Tools
         protected override void PostRenderMap(Graphics graphics)
         {
             base.PostRenderMap(graphics);
-
-            var unitPen = new Pen(Color.Green, 4.0f);
-            foreach (var (topLeft, _) in map.Technos.OfType<Unit>())
+            using (var unitPen = new Pen(Color.Green, 4.0f))
             {
-                var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
-                graphics.DrawRectangle(unitPen, bounds);
+                foreach (var (topLeft, _) in map.Technos.OfType<Unit>())
+                {
+                    var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
+                    graphics.DrawRectangle(unitPen, bounds);
+                }
             }
         }
 

--- a/CnCTDRAMapEditor/Tools/ViewTool.cs
+++ b/CnCTDRAMapEditor/Tools/ViewTool.cs
@@ -124,119 +124,121 @@ namespace MobiusEditor.Tools
         {
             if ((Layers & MapLayerFlag.Waypoints) != MapLayerFlag.None)
             {
-                var waypointBackgroundBrush = new SolidBrush(Color.FromArgb(96, Color.Black));
-                var waypointBrush = new SolidBrush(Color.FromArgb(128, Color.DarkOrange));
-                var waypointPen = new Pen(Color.DarkOrange);
-
-                foreach (var waypoint in map.Waypoints)
+                using (var waypointBackgroundBrush = new SolidBrush(Color.FromArgb(96, Color.Black)))
+                using (var waypointBrush = new SolidBrush(Color.FromArgb(128, Color.DarkOrange)))
+                using (var waypointPen = new Pen(Color.DarkOrange))
                 {
-                    if (waypoint.Cell.HasValue)
+                    foreach (var waypoint in map.Waypoints)
                     {
-                        var x = waypoint.Cell.Value % map.Metrics.Width;
-                        var y = waypoint.Cell.Value / map.Metrics.Width;
-
-                        var location = new Point(x * Globals.TileWidth, y * Globals.TileHeight);
-                        var textBounds = new Rectangle(location, Globals.TileSize);
-
-                        graphics.FillRectangle(waypointBackgroundBrush, textBounds);
-                        graphics.DrawRectangle(waypointPen, textBounds);
-
-                        StringFormat stringFormat = new StringFormat
+                        if (waypoint.Cell.HasValue)
                         {
-                            Alignment = StringAlignment.Center,
-                            LineAlignment = StringAlignment.Center
-                        };
+                            var x = waypoint.Cell.Value % map.Metrics.Width;
+                            var y = waypoint.Cell.Value / map.Metrics.Width;
 
-                        var text = waypoint.Name.ToString();
-                        var font = graphics.GetAdjustedFont(text, SystemFonts.DefaultFont, textBounds.Width, 24 / Globals.TileScale, 48 / Globals.TileScale, true);
-                        graphics.DrawString(text.ToString(), font, waypointBrush, textBounds, stringFormat);
+                            var location = new Point(x * Globals.TileWidth, y * Globals.TileHeight);
+                            var textBounds = new Rectangle(location, Globals.TileSize);
+
+                            graphics.FillRectangle(waypointBackgroundBrush, textBounds);
+                            graphics.DrawRectangle(waypointPen, textBounds);
+
+                            StringFormat stringFormat = new StringFormat
+                            {
+                                Alignment = StringAlignment.Center,
+                                LineAlignment = StringAlignment.Center
+                            };
+
+                            var text = waypoint.Name.ToString();
+                            var font = graphics.GetAdjustedFont(text, SystemFonts.DefaultFont, textBounds.Width, 24 / Globals.TileScale, 48 / Globals.TileScale, true);
+                            graphics.DrawString(text.ToString(), font, waypointBrush, textBounds, stringFormat);
+                        }
                     }
                 }
             }
 
             if ((Layers & MapLayerFlag.TechnoTriggers) != MapLayerFlag.None)
             {
-                var technoTriggerBackgroundBrush = new SolidBrush(Color.FromArgb(96, Color.Black));
-                var technoTriggerBrush = new SolidBrush(Color.LimeGreen);
-                var technoTriggerPen = new Pen(Color.LimeGreen);
-
-                foreach (var (cell, techno) in map.Technos)
+                using (var technoTriggerBackgroundBrush = new SolidBrush(Color.FromArgb(96, Color.Black)))
+                using (var technoTriggerBrush = new SolidBrush(Color.LimeGreen))
+                using (var technoTriggerPen = new Pen(Color.LimeGreen))
                 {
-                    var location = new Point(cell.X * Globals.TileWidth, cell.Y * Globals.TileHeight);
+                    foreach (var (cell, techno) in map.Technos)
+                    {
+                        var location = new Point(cell.X * Globals.TileWidth, cell.Y * Globals.TileHeight);
 
-                    (string trigger, Rectangle bounds)[] triggers = null;
-                    if (techno is Terrain terrain)
-                    {
-                        triggers = new (string, Rectangle)[] { (terrain.Trigger, new Rectangle(location, terrain.Type.RenderSize)) };
-                    }
-                    else if (techno is Building building)
-                    {
-                        var size = new Size(building.Type.Size.Width * Globals.TileWidth, building.Type.Size.Height * Globals.TileHeight);
-                        triggers = new (string, Rectangle)[] { (building.Trigger, new Rectangle(location, size)) };
-                    }
-                    else if (techno is Unit unit)
-                    {
-                        triggers = new (string, Rectangle)[] { (unit.Trigger, new Rectangle(location, Globals.TileSize)) };
-                    }
-                    else if (techno is InfantryGroup infantryGroup)
-                    {
-                        List<(string, Rectangle)> infantryTriggers = new List<(string, Rectangle)>();
-                        for (var i = 0; i < infantryGroup.Infantry.Length; ++i)
+                        (string trigger, Rectangle bounds)[] triggers = null;
+                        if (techno is Terrain terrain)
                         {
-                            var infantry = infantryGroup.Infantry[i];
-                            if (infantry == null)
+                            triggers = new (string, Rectangle)[] { (terrain.Trigger, new Rectangle(location, terrain.Type.RenderSize)) };
+                        }
+                        else if (techno is Building building)
+                        {
+                            var size = new Size(building.Type.Size.Width * Globals.TileWidth, building.Type.Size.Height * Globals.TileHeight);
+                            triggers = new (string, Rectangle)[] { (building.Trigger, new Rectangle(location, size)) };
+                        }
+                        else if (techno is Unit unit)
+                        {
+                            triggers = new (string, Rectangle)[] { (unit.Trigger, new Rectangle(location, Globals.TileSize)) };
+                        }
+                        else if (techno is InfantryGroup infantryGroup)
+                        {
+                            List<(string, Rectangle)> infantryTriggers = new List<(string, Rectangle)>();
+                            for (var i = 0; i < infantryGroup.Infantry.Length; ++i)
                             {
-                                continue;
+                                var infantry = infantryGroup.Infantry[i];
+                                if (infantry == null)
+                                {
+                                    continue;
+                                }
+
+                                var size = Globals.TileSize;
+                                var offset = Size.Empty;
+                                switch ((InfantryStoppingType)i)
+                                {
+                                    case InfantryStoppingType.UpperLeft:
+                                        offset.Width = -size.Width / 4;
+                                        offset.Height = -size.Height / 4;
+                                        break;
+                                    case InfantryStoppingType.UpperRight:
+                                        offset.Width = size.Width / 4;
+                                        offset.Height = -size.Height / 4;
+                                        break;
+                                    case InfantryStoppingType.LowerLeft:
+                                        offset.Width = -size.Width / 4;
+                                        offset.Height = size.Height / 4;
+                                        break;
+                                    case InfantryStoppingType.LowerRight:
+                                        offset.Width = size.Width / 4;
+                                        offset.Height = size.Height / 4;
+                                        break;
+                                }
+
+                                var bounds = new Rectangle(location + offset, size);
+                                infantryTriggers.Add((infantry.Trigger, bounds));
                             }
 
-                            var size = Globals.TileSize;
-                            var offset = Size.Empty;
-                            switch ((InfantryStoppingType)i)
-                            {
-                                case InfantryStoppingType.UpperLeft:
-                                    offset.Width = -size.Width / 4;
-                                    offset.Height = -size.Height / 4;
-                                    break;
-                                case InfantryStoppingType.UpperRight:
-                                    offset.Width = size.Width / 4;
-                                    offset.Height = -size.Height / 4;
-                                    break;
-                                case InfantryStoppingType.LowerLeft:
-                                    offset.Width = -size.Width / 4;
-                                    offset.Height = size.Height / 4;
-                                    break;
-                                case InfantryStoppingType.LowerRight:
-                                    offset.Width = size.Width / 4;
-                                    offset.Height = size.Height / 4;
-                                    break;
-                            }
-
-                            var bounds = new Rectangle(location + offset, size);
-                            infantryTriggers.Add((infantry.Trigger, bounds));
+                            triggers = infantryTriggers.ToArray();
                         }
 
-                        triggers = infantryTriggers.ToArray();
-                    }
-
-                    if (triggers != null)
-                    {
-                        StringFormat stringFormat = new StringFormat
+                        if (triggers != null)
                         {
-                            Alignment = StringAlignment.Center,
-                            LineAlignment = StringAlignment.Center
-                        };
+                            StringFormat stringFormat = new StringFormat
+                            {
+                                Alignment = StringAlignment.Center,
+                                LineAlignment = StringAlignment.Center
+                            };
 
-                        foreach (var (trigger, bounds) in triggers.Where(x => !x.trigger.Equals("None", StringComparison.OrdinalIgnoreCase)))
-                        {
-                            var font = graphics.GetAdjustedFont(trigger, SystemFonts.DefaultFont, bounds.Width, 12 / Globals.TileScale, 24 / Globals.TileScale, true);
-                            var textBounds = graphics.MeasureString(trigger, font, bounds.Width, stringFormat);
+                            foreach (var (trigger, bounds) in triggers.Where(x => !x.trigger.Equals("None", StringComparison.OrdinalIgnoreCase)))
+                            {
+                                var font = graphics.GetAdjustedFont(trigger, SystemFonts.DefaultFont, bounds.Width, 12 / Globals.TileScale, 24 / Globals.TileScale, true);
+                                var textBounds = graphics.MeasureString(trigger, font, bounds.Width, stringFormat);
 
-                            var backgroundBounds = new RectangleF(bounds.Location, textBounds);
-                            backgroundBounds.Offset((bounds.Width - textBounds.Width) / 2.0f, (bounds.Height - textBounds.Height) / 2.0f);
-                            graphics.FillRectangle(technoTriggerBackgroundBrush, backgroundBounds);
-                            graphics.DrawRectangle(technoTriggerPen, Rectangle.Round(backgroundBounds));
+                                var backgroundBounds = new RectangleF(bounds.Location, textBounds);
+                                backgroundBounds.Offset((bounds.Width - textBounds.Width) / 2.0f, (bounds.Height - textBounds.Height) / 2.0f);
+                                graphics.FillRectangle(technoTriggerBackgroundBrush, backgroundBounds);
+                                graphics.DrawRectangle(technoTriggerPen, Rectangle.Round(backgroundBounds));
 
-                            graphics.DrawString(trigger, font, technoTriggerBrush, bounds, stringFormat);
+                                graphics.DrawString(trigger, font, technoTriggerBrush, bounds, stringFormat);
+                            }
                         }
                     }
                 }
@@ -244,43 +246,44 @@ namespace MobiusEditor.Tools
 
             if ((Layers & MapLayerFlag.CellTriggers) != MapLayerFlag.None)
             {
-                var cellTriggersBackgroundBrush = new SolidBrush(Color.FromArgb(96, Color.Black));
-                var cellTriggersBrush = new SolidBrush(Color.FromArgb(128, Color.White));
-                var cellTriggerPen = new Pen(Color.White);
-
-                foreach (var (cell, cellTrigger) in map.CellTriggers)
+                using (var cellTriggersBackgroundBrush = new SolidBrush(Color.FromArgb(96, Color.Black)))
+                using (var cellTriggersBrush = new SolidBrush(Color.FromArgb(128, Color.White)))
+                using (var cellTriggerPen = new Pen(Color.White))
                 {
-                    var x = cell % map.Metrics.Width;
-                    var y = cell / map.Metrics.Width;
-
-                    var location = new Point(x * Globals.TileWidth, y * Globals.TileHeight);
-                    var textBounds = new Rectangle(location, Globals.TileSize);
-
-                    graphics.FillRectangle(cellTriggersBackgroundBrush, textBounds);
-                    graphics.DrawRectangle(cellTriggerPen, textBounds);
-
-                    StringFormat stringFormat = new StringFormat
+                    foreach (var (cell, cellTrigger) in map.CellTriggers)
                     {
-                        Alignment = StringAlignment.Center,
-                        LineAlignment = StringAlignment.Center
-                    };
+                        var x = cell % map.Metrics.Width;
+                        var y = cell / map.Metrics.Width;
 
-                    var text = cellTrigger.Trigger;
-                    var font = graphics.GetAdjustedFont(text, SystemFonts.DefaultFont, textBounds.Width, 24 / Globals.TileScale, 48 / Globals.TileScale, true);
-                    graphics.DrawString(text.ToString(), font, cellTriggersBrush, textBounds, stringFormat);
+                        var location = new Point(x * Globals.TileWidth, y * Globals.TileHeight);
+                        var textBounds = new Rectangle(location, Globals.TileSize);
+
+                        graphics.FillRectangle(cellTriggersBackgroundBrush, textBounds);
+                        graphics.DrawRectangle(cellTriggerPen, textBounds);
+
+                        StringFormat stringFormat = new StringFormat
+                        {
+                            Alignment = StringAlignment.Center,
+                            LineAlignment = StringAlignment.Center
+                        };
+
+                        var text = cellTrigger.Trigger;
+                        var font = graphics.GetAdjustedFont(text, SystemFonts.DefaultFont, textBounds.Width, 24 / Globals.TileScale, 48 / Globals.TileScale, true);
+                        graphics.DrawString(text.ToString(), font, cellTriggersBrush, textBounds, stringFormat);
+                    }
                 }
             }
 
             if ((Layers & MapLayerFlag.Boundaries) != MapLayerFlag.None)
             {
-                var boundsPen = new Pen(Color.Cyan, 8.0f);
                 var bounds = Rectangle.FromLTRB(
                     map.Bounds.Left * Globals.TileWidth,
                     map.Bounds.Top * Globals.TileHeight,
                     map.Bounds.Right * Globals.TileWidth,
                     map.Bounds.Bottom * Globals.TileHeight
                 );
-                graphics.DrawRectangle(boundsPen, bounds);
+                using (var boundsPen = new Pen(Color.Cyan, 8.0f))
+                    graphics.DrawRectangle(boundsPen, bounds);
             }
         }
 

--- a/CnCTDRAMapEditor/Tools/WallsTool.cs
+++ b/CnCTDRAMapEditor/Tools/WallsTool.cs
@@ -335,14 +335,16 @@ namespace MobiusEditor.Tools
         {
             base.PostRenderMap(graphics);
 
-            var wallPen = new Pen(Color.Green, 4.0f);
-            foreach (var (cell, overlay) in previewMap.Overlay)
+            using (var wallPen = new Pen(Color.Green, 4.0f))
             {
-                if (overlay.Type.IsWall)
+                foreach (var (cell, overlay) in previewMap.Overlay)
                 {
-                    previewMap.Metrics.GetLocation(cell, out Point topLeft);
-                    var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
-                    graphics.DrawRectangle(wallPen, bounds);
+                    if (overlay.Type.IsWall)
+                    {
+                        previewMap.Metrics.GetLocation(cell, out Point topLeft);
+                        var bounds = new Rectangle(new Point(topLeft.X * Globals.TileWidth, topLeft.Y * Globals.TileHeight), Globals.TileSize);
+                        graphics.DrawRectangle(wallPen, bounds);
+                    }
                 }
             }
         }

--- a/CnCTDRAMapEditor/Widgets/NavigationWidget.cs
+++ b/CnCTDRAMapEditor/Widgets/NavigationWidget.cs
@@ -131,9 +131,14 @@ namespace MobiusEditor.Widgets
 
         public void Render(Graphics graphics)
         {
+            RenderRect(graphics, MouseCell);
+        }
+
+        public void RenderRect(Graphics graphics, Point mouseCell)
+        {
             if (!MouseoverSize.IsEmpty)
             {
-                var rect = new Rectangle(new Point(MouseCell.X * cellSize.Width, MouseCell.Y * cellSize.Height), cellSize);
+                var rect = new Rectangle(new Point(mouseCell.X * cellSize.Width, mouseCell.Y * cellSize.Height), cellSize);
                 rect.Inflate(cellSize.Width * (MouseoverSize.Width / 2), cellSize.Height * (MouseoverSize.Height / 2));
                 graphics.DrawRectangle(defaultMouseoverPen, rect);
             }

--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
-## Note: I am no longer working on this project. This repository still exists for archival purposes and so that people can fork it and continue the project if they wish. 
-
-### Old readme follows:
-
 ## C&C Tiberian Dawn and Red Alert Map Editor
 
 An enhanced version of the C&C Tiberian Dawn and Red Alert Map Editor based on the source code released by Electronic Arts.
 The goal of the project is simply to improve the usability and convenience of the map editor, fix bugs, improve and clean its code-base,
 enhance compatibility with different kinds of systems and enhance the editor's support for mods.
 
-Once the project has proceeded far enough and I am pleased with the state of the editor, I might also look into making it support Tiberian Sun.
-
-### Current features
+### Features added by Rampastring:
 
 * Downsized menu graphics by an user-configurable factor so you can see more placeable object types at once on sub-4K monitors
 * Improved zoom levels
@@ -18,22 +12,28 @@ Once the project has proceeded far enough and I am pleased with the state of the
 * Made tool windows remember their previous position, size and other settings upon closing and re-opening them
 * Replaced drop-downs with list boxes in object type selection dialogs to allow switching between objects with fewer clicks 
 
-This list will be kept up-to-date as more features are added.
+### Features and fixes by Nyerguds (so far):
 
-### Installation and usage
-
-To install, simply download a compiled build from the [Releases section of this repository](https://github.com/Rampastring/CnCTDRAMapEditor/releases)
-and unzip the build into a new directory.
-**Do not overwrite the original map editor that comes with the C&C Remastered Collection**. The map editor will ask for your game
-directory on first launch and then load all assets from the specified directory.
-
-If you wish to compile and run the map editor from source code, simply clone this repository and open it
-with Visual Studio 2017 or later with support for .NET desktop development installed.
+* Fixed Overlay height overflow bug in Rampa's new UI.
+* Fixed tiles list duplicating every time the "Map" tool window is opened.
+* Split off internal Overlay type "decoration", used for pavements and civilian buildings.
+* Added CONC and ROAD pavement. They have no graphics, but at least now they are accepted by the editor and not discarded as errors.
+* Sorted all items in the lists (except map tiles) by key, which is usually a lot more straightforward.
+* Split off specific separate list for techno types usable in teamtypes.
+* Removed the Aircraft from the placeable units in TD.
+* Removed irrelevant orders from the unit missions list (Selling, Missile, etc.)
+* Fixed case sensitivity related crashes in TD teamtypes.
+* Added Ctrl-N, Ctrl+O, Ctrl+S etc shortcuts for the File menu.
+* Fixed double indicator on map tile selection window.
+* Fixed smudge reading in TD to allow 5 crater stages.
+* Added tooltip window to adjust crater stage.
+* Fixed Terrain objects not saving their trigger. Note that only "Attacked" triggers work on them.
+* Red Alert "Spied by..." trigger event now shows the House to select.
+* Added "Add" buttons in triggers and teamtypes dialogs.
+* Fixed tab order in triggers and teamtypes dialogs.
+* Fixed crash in "already exists" messages for triggers and teams.
+* [EXPERIMENTAL] Added ability to place bibs. They won't show their full size in the editor at the moment, though.
 
 ### Contributing
 
-Contributions are welcome in the scope of the project. If there's a bug that you'd like to fix or functionality that you'd like to enhance, feel free to make an issue for discussing it or a pull request if you'd want to push code.
-
-### Contact
-
-You can find me and discuss features on the Assembly Armada's [Discord server](https://discord.gg/UnWK2Tw). Note that this project is not officially affiliated with [The Assembly Armada](https://github.com/TheAssemblyArmada), but their server has become a general hub for discussing the released C&C source code and C&C reverse-engineering efforts, which provides a fitting context for this map editor.
+Right now, I'm not really looking into making this a joint project. Specific bug reports and suggestions are always welcome though.


### PR DESCRIPTION
* Fixed Overlay height overflow bug in Rampa's new UI.
* Fixed tiles list duplicating every time the "Map" tool window is opened.
* Split off internal Overlay type "decoration", used for pavements and civilian buildings.
* Added CONC and ROAD pavement. They have no graphics, but at least now they are accepted by the editor and not discarded as errors.
* Sorted all items in the lists (except map tiles) by key, which is usually a lot more straightforward.
* Split off specific separate list for techno types usable in teamtypes.
* Removed the Aircraft from the placeable units in TD.
* Removed irrelevant orders from the unit missions list (Selling, Missile, etc.)
* Fixed case sensitivity related crashes in TD teamtypes.
* Added Ctrl-N, Ctrl+O, Ctrl+S etc shortcuts for the File menu.
* Fixed double indicator on map tile selection window.
* Fixed smudge reading in TD to allow 5 crater stages.
* Added tooltip window to adjust crater stage.
* Fixed Terrain objects not saving their trigger. Note that only "Attacked" triggers work on them.
* Red Alert "Spied by..." trigger event now shows the House to select.
* Added "Add" buttons in triggers and teamtypes dialogs.
* Fixed tab order in triggers and teamtypes dialogs.
* Fixed crash in "already exists" messages for triggers and teams.
* [EXPERIMENTAL] Added ability to place bibs. They won't show their full size in the editor at the moment, though.